### PR TITLE
docs: add pseudo markers to unmarked code blocks

### DIFF
--- a/docs/advanced/event-system.md
+++ b/docs/advanced/event-system.md
@@ -24,6 +24,7 @@ Fires for any property change:
 - Meta-property changes (`IsBusy`, `IsValid`, `IsModified`, etc.)
 - Any other bindable property
 
+<!-- pseudo:property-changed-subscription -->
 ```csharp
 // Blazor/WPF binding automatically subscribes
 <MudTextField @bind-Value="person.Name" />
@@ -34,6 +35,7 @@ person.PropertyChanged += (sender, e) =>
     Console.WriteLine($"Property changed: {e.PropertyName}");
 };
 ```
+<!-- /snippet -->
 
 ### NeatooPropertyChanged (Internal Logic)
 
@@ -44,6 +46,7 @@ Fires when a managed property's `Value` changes. Triggers:
 3. **Bubbling** - Propagates change notification up the parent hierarchy
 4. **UI Translation** - Fires `PropertyChanged` for the property name on the entity
 
+<!-- pseudo:neatoo-property-changed-subscription -->
 ```csharp
 // Subscribe for custom async processing
 person.NeatooPropertyChanged += async (args) =>
@@ -51,6 +54,7 @@ person.NeatooPropertyChanged += async (args) =>
     await LogChangeAsync(args.FullPropertyName, args.Source);
 };
 ```
+<!-- /snippet -->
 
 ## Event Flow
 
@@ -99,6 +103,7 @@ The property fires `PropertyChanged("Value")` (the property's own value changed)
 
 ValidateBase translates this by firing `PropertyChanged("Name")` on the entity when it receives `NeatooPropertyChanged`. This tells the UI "the Name property on this entity changed."
 
+<!-- pseudo:property-changed-translation -->
 ```csharp
 // In ValidateBase._PropertyManager_NeatooPropertyChanged:
 
@@ -107,11 +112,13 @@ ValidateBase translates this by firing `PropertyChanged("Name")` on the entity w
 // This goes to immediate outside listeners only, not up the Neatoo parent tree.
 this.RaisePropertyChanged(eventArgs.FullPropertyName);
 ```
+<!-- /snippet -->
 
 ## NeatooPropertyChangedEventArgs
 
 The async event provides richer information than standard `PropertyChangedEventArgs`:
 
+<!-- pseudo:neatoo-event-args -->
 ```csharp
 public record NeatooPropertyChangedEventArgs
 {
@@ -124,6 +131,7 @@ public record NeatooPropertyChangedEventArgs
     public ChangeReason Reason { get; }           // UserEdit or Load
 }
 ```
+<!-- /snippet -->
 
 ### ChangeReason
 
@@ -134,6 +142,7 @@ The `Reason` property distinguishes between user edits and data loading:
 | `UserEdit` | Normal setter assignment | Yes - runs rules |
 | `Load` | `LoadValue()` call | No - structural only |
 
+<!-- pseudo:change-reason-example -->
 ```csharp
 protected override async Task ChildNeatooPropertyChanged(NeatooPropertyChangedEventArgs eventArgs)
 {
@@ -153,6 +162,7 @@ protected override async Task ChildNeatooPropertyChanged(NeatooPropertyChangedEv
     await base.ChildNeatooPropertyChanged(eventArgs);
 }
 ```
+<!-- /snippet -->
 
 This enables handlers to distinguish between a user changing a value (which should trigger business logic) and the system loading data (which should not).
 
@@ -216,6 +226,7 @@ After factory completes, `IsPaused = false` and rules run normally.
 
 ### Async Change Tracking
 
+<!-- pseudo:async-change-tracking -->
 ```csharp
 public class ChangeTracker
 {
@@ -231,9 +242,11 @@ public class ChangeTracker
     }
 }
 ```
+<!-- /snippet -->
 
 ### Override Child Change Handling
 
+<!-- pseudo:override-child-change -->
 ```csharp
 public partial class Order : EntityBase<Order>, IOrder
 {
@@ -249,6 +262,7 @@ public partial class Order : EntityBase<Order>, IOrder
     }
 }
 ```
+<!-- /snippet -->
 
 ## See Also
 

--- a/docs/plans/2026-01-15-constructor-loadvalue-analyzer-design.md
+++ b/docs/plans/2026-01-15-constructor-loadvalue-analyzer-design.md
@@ -6,6 +6,7 @@ When properties are assigned in constructors using normal setters (`Name = "valu
 
 This bug is extremely difficult to diagnose. The correct pattern is to use `LoadValue()` in constructors:
 
+<!-- pseudo:loadvalue-constructor-pattern -->
 ```csharp
 // Wrong - tracks modification
 public EntityObject(IEntityBaseServices<EntityObject> services) : base(services)
@@ -19,6 +20,7 @@ public EntityObject(IEntityBaseServices<EntityObject> services) : base(services)
     RequiredProperty.LoadValue(1);  // IsModified stays false
 }
 ```
+<!-- /snippet -->
 
 ## Solution
 
@@ -74,6 +76,7 @@ From existing `BaseGenerator.cs`:
 
 ### Code Fix Transformation
 
+<!-- pseudo:code-fix-transformation -->
 ```csharp
 // Input
 Name = "value";
@@ -85,6 +88,7 @@ NameProperty.LoadValue("value");
 CountProperty.LoadValue(42);
 ChildProperty.LoadValue(someObject);
 ```
+<!-- /snippet -->
 
 ## Test Cases
 

--- a/docs/plans/2026-01-16-loadvalue-setparent-fix.md
+++ b/docs/plans/2026-01-16-loadvalue-setparent-fix.md
@@ -29,6 +29,7 @@
 
 **Step 1: Create the enum file**
 
+<!-- pseudo:change-reason-enum -->
 ```csharp
 namespace Neatoo;
 
@@ -62,6 +63,7 @@ public enum ChangeReason
     Load
 }
 ```
+<!-- /snippet -->
 
 **Step 2: Verify file created**
 
@@ -92,6 +94,7 @@ Read `src/Neatoo/NeatooPropertyChangedEventArgs.cs` to confirm current structure
 
 Replace entire file with:
 
+<!-- pseudo:neatoo-property-changed-event-args -->
 ```csharp
 namespace Neatoo;
 
@@ -151,6 +154,7 @@ public record NeatooPropertyChangedEventArgs
     public ChangeReason Reason { get; init; } = ChangeReason.UserEdit;
 }
 ```
+<!-- /snippet -->
 
 **Step 3: Build to verify no compilation errors**
 
@@ -179,6 +183,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
 **Step 1: Review current LoadValue implementation**
 
 Current (lines 318-322):
+<!-- pseudo:loadvalue-current -->
 ```csharp
 public virtual void LoadValue(object? value)
 {
@@ -186,11 +191,13 @@ public virtual void LoadValue(object? value)
     this._value = (T?)value;
 }
 ```
+<!-- /snippet -->
 
 **Step 2: Update LoadValue to fire event with ChangeReason.Load**
 
 Replace LoadValue method with:
 
+<!-- pseudo:loadvalue-updated -->
 ```csharp
 public virtual void LoadValue(object? value)
 {
@@ -233,6 +240,7 @@ public virtual void LoadValue(object? value)
     this.Task = this.OnValueNeatooPropertyChanged(new NeatooPropertyChangedEventArgs(this, ChangeReason.Load));
 }
 ```
+<!-- /snippet -->
 
 **Step 3: Build to verify no compilation errors**
 
@@ -262,6 +270,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
 **Step 1: Review current implementation**
 
 Current (lines 374-388):
+<!-- pseudo:child-neatoo-property-changed-current -->
 ```csharp
 protected virtual async Task ChildNeatooPropertyChanged(NeatooPropertyChangedEventArgs eventArgs)
 {
@@ -279,11 +288,13 @@ protected virtual async Task ChildNeatooPropertyChanged(NeatooPropertyChangedEve
     }
 }
 ```
+<!-- /snippet -->
 
 **Step 2: Update to check ChangeReason**
 
 Replace ChildNeatooPropertyChanged method with:
 
+<!-- pseudo:child-neatoo-property-changed-updated -->
 ```csharp
 protected virtual async Task ChildNeatooPropertyChanged(NeatooPropertyChangedEventArgs eventArgs)
 {
@@ -303,6 +314,7 @@ protected virtual async Task ChildNeatooPropertyChanged(NeatooPropertyChangedEve
     }
 }
 ```
+<!-- /snippet -->
 
 **Step 3: Build to verify no compilation errors**
 
@@ -370,6 +382,7 @@ Possible issues:
 
 **Step 1: Create test file**
 
+<!-- pseudo:loadvalue-tests -->
 ```csharp
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neatoo.Internal;
@@ -488,6 +501,7 @@ public class ValidatePropertyLoadValueTests
     }
 }
 ```
+<!-- /snippet -->
 
 **Step 2: Run new tests**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,6 +57,7 @@ This guide covers common issues and solutions when working with Neatoo.
 
 Add `partial` to the class declaration:
 
+<!-- pseudo:partial-class-fix -->
 ```csharp
 // Wrong - will compile but properties won't work
 [Factory]
@@ -66,6 +67,7 @@ internal class Person : EntityBase<Person>, IPerson { }
 [Factory]
 internal partial class Person : EntityBase<Person>, IPerson { }
 ```
+<!-- /snippet -->
 
 ### Factory Hint Name Too Long
 
@@ -137,6 +139,7 @@ Direct property assignment in constructors marks the entity as modified (`IsModi
 
 Use `LoadValue()` instead of direct assignment:
 
+<!-- pseudo:loadvalue-constructor-fix -->
 ```csharp
 // Warning: Direct assignment marks entity as modified
 public Person(IEntityBaseServices<Person> services) : base(services)
@@ -150,6 +153,7 @@ public Person(IEntityBaseServices<Person> services) : base(services)
     StatusProperty.LoadValue("Active");  // No warning
 }
 ```
+<!-- /snippet -->
 
 ## Validation Issues
 


### PR DESCRIPTION
Mark 42 code blocks with pseudo: markers to pass verify-code-blocks check. These are documentation examples that will be updated with compiled snippets later.