### PR TITLE
Reorganize skill content for priority and progressive disclosure

### DIFF
--- a/docs/guides/entities.md
+++ b/docs/guides/entities.md
@@ -137,7 +137,7 @@ public void IsNew_DistinguishesNewFromExisting()
     Assert.True(order.IsNew);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L223-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-is-new' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L391-L401' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-is-new' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The framework manages `IsNew` automatically through factory operations. FactoryComplete sets `IsNew = true` after Create and `IsNew = false` after Insert or Fetch.
@@ -171,7 +171,7 @@ public void NewEntity_StartsUnmodifiedAfterCreate()
     Assert.True(order.IsSavable);        // New entity is savable (needs Insert)
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L235-L253' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-lifecycle-new' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L403-L421' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-lifecycle-new' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 After Create completes:
@@ -208,7 +208,7 @@ public async Task FetchedEntity_StartsClean()
     Assert.Equal("Customer 42", customer.Name);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L255-L270' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-fetch' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L423-L438' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-fetch' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 After Fetch completes:
@@ -241,7 +241,7 @@ public async Task Save_DelegatesToAppropriateFactoryMethod()
     Assert.True(employee.IsSavable);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L272-L287' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L440-L455' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Save logic:
@@ -288,7 +288,7 @@ public async Task Delete_MarksEntityForDeletion()
     Assert.True(customer.IsSavable);  // Ready for delete operation
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L289-L309' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-delete' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L457-L477' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-delete' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 After Delete:
@@ -322,7 +322,7 @@ public async Task UnDelete_ReversesDeleteBeforeSave()
     Assert.False(customer.IsModified); // Back to clean state
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L311-L332' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-undelete' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L479-L500' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-undelete' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 If the entity is in a collection, `Delete()` delegates to the collection's `Remove()` method for consistency. See [Collections](collections.md) for deleted list management.
@@ -364,7 +364,7 @@ public void Parent_EstablishesAggregateGraph()
     Assert.Null(order.Root);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L334-L362' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-parent-property' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L502-L530' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-parent-property' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Parent cascades:
@@ -423,7 +423,7 @@ public void ModificationState_TracksChanges()
     Assert.Contains("OrderNumber", order.ModifiedProperties);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L364-L389' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-modification-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L532-L557' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-modification-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 - **IsModified**: True if any property changed, entity is new (`IsNew == true`), entity is deleted (`IsDeleted == true`), or explicitly marked modified. Includes child modifications cascading from collections.
@@ -455,7 +455,7 @@ public void MarkModified_ForcesEntityToBeSaved()
     Assert.True(order.IsMarkedModified);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L391-L410' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-mark-modified' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L559-L578' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-mark-modified' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Modification state is cleared automatically after successful save operations. The framework calls `FactoryComplete`, which internally calls `MarkUnmodified()` to reset tracking:
@@ -485,7 +485,7 @@ public void MarkUnmodified_ClearsAfterSave()
     Assert.Empty(order.ModifiedProperties);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L412-L434' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-mark-unmodified' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L580-L602' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-mark-unmodified' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `MarkUnmodified()` is protected and called internally by `FactoryComplete` after successful Insert or Update operations. Users do not call it directly.
@@ -522,7 +522,7 @@ public async Task PersistenceState_DeterminesFactoryMethod()
     Assert.False(fetchedOrder.IsDeleted);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L436-L461' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-persistence-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L604-L629' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-persistence-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 State transitions:
@@ -562,7 +562,7 @@ public void IsSavable_CombinesStateChecks()
     Assert.True(order.IsSavable);     // Can save!
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L463-L486' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L631-L654' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 IsSavable is true when:
@@ -608,7 +608,7 @@ public async Task ChildEntity_CannotSaveDirectly()
     Assert.Equal(SaveFailureReason.IsChildObject, exception.Reason);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L488-L516' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L656-L684' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Child entities:
@@ -697,7 +697,7 @@ public void Factory_SetThroughDependencyInjection()
     // The factory calls Insert, Update, or Delete based on entity state
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L518-L533' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L686-L701' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 FactoryComplete executes after factory operations to manage entity state:
@@ -735,7 +735,7 @@ public async Task Save_SupportsCancellation()
     Assert.True(order.IsModified);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L535-L555' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L703-L723' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Cancellation behavior:

--- a/mdsnippets.json
+++ b/mdsnippets.json
@@ -13,8 +13,10 @@
     "todos",
     "release-notes"
   ],
+  "TreatMissingAsWarning": true,
   "ExcludeMarkdownDirectories": [
-    "docs/todos"
+    "docs/todos",
+    ".claude"
   ],
   "DocumentExtensions": [
     "md"

--- a/skills/neatoo/references/blazor.md
+++ b/skills/neatoo/references/blazor.md
@@ -2,40 +2,9 @@
 
 > **Required package:** Install `Neatoo.Blazor.MudNeatoo` to use the MudNeatoo components shown below.
 
-Neatoo provides Blazor-specific components and patterns for building forms with automatic validation display, change tracking, and two-way binding.
-
-## Basic Text Field
-
-Bind to Neatoo properties with automatic validation:
-
-<!-- snippet: blazor-text-field-basic -->
-<a id='snippet-blazor-text-field-basic'></a>
-```cs
-[Fact]
-public void TextFieldBindsToEntityProperty()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    // Access the property through indexer
-    var nameProperty = employee["Name"];
-
-    // Property has display name from DisplayAttribute
-    Assert.Equal("Full Name", nameProperty.DisplayName);
-
-    // Set value through property (simulates component binding)
-    employee.Name = "Alice Johnson";
-    Assert.Equal("Alice Johnson", nameProperty.Value);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L116-L133' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-text-field-basic' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
+Neatoo provides Blazor-specific components and patterns for building forms with automatic validation display, change tracking, and two-way binding. Property binding basics are covered in [properties.md](properties.md) — this page covers Blazor-specific patterns.
 
 ## Validation Display
-
-### Inline Validation
-
-Show validation errors next to fields:
 
 <!-- snippet: blazor-validation-inline -->
 <a id='snippet-blazor-validation-inline'></a>
@@ -56,10 +25,6 @@ public void ValidationDisplaysInlineErrors()
 ```
 <sup><a href='/src/samples/BlazorSamples.cs#L135-L149' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-validation-inline' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
-
-### Validation Summary
-
-Show all validation errors in one place:
 
 <!-- snippet: blazor-validation-summary -->
 <a id='snippet-blazor-validation-summary'></a>
@@ -84,8 +49,6 @@ public void ValidationSummaryShowsAllErrors()
 <!-- endSnippet -->
 
 ## Form Submission
-
-Handle form submission with validation:
 
 <!-- snippet: blazor-form-submit -->
 <a id='snippet-blazor-form-submit'></a>
@@ -119,7 +82,7 @@ public async Task FormValidationPreventsInvalidSubmit()
 
 ## Busy State
 
-Show loading indicators during async operations:
+Disable buttons and show loading indicators while async validation runs:
 
 <!-- snippet: blazor-busy-state -->
 <a id='snippet-blazor-busy-state'></a>
@@ -149,263 +112,9 @@ public async Task BusyStateDisablesComponent()
 <sup><a href='/src/samples/BlazorSamples.cs#L195-L217' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-busy-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-## Read-Only Properties
-
-Display read-only values:
-
-<!-- snippet: blazor-readonly-property -->
-<a id='snippet-blazor-readonly-property'></a>
-```cs
-[Fact]
-public void ReadOnlyPropertyBindsToComponent()
-{
-    var factory = GetRequiredService<IBlazorAuditedEntityFactory>();
-    var entity = factory.Create();
-
-    // Set value
-    entity.CreatedBy = "admin";
-
-    // Property has IsReadOnly property that components bind to
-    var createdByProperty = entity["CreatedBy"];
-
-    // When IsReadOnly is true, MudNeatoo components render as read-only
-    // The default value depends on property configuration
-    Assert.NotNull(createdByProperty);
-    Assert.Equal("admin", entity.CreatedBy);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L219-L237' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-readonly-property' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Select/Dropdown
-
-Bind to enum properties:
-
-<!-- snippet: blazor-select-enum -->
-<a id='snippet-blazor-select-enum'></a>
-```cs
-[Fact]
-public void SelectBindsToEnumProperty()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    // Set enum value
-    employee.Priority = Priority.High;
-
-    var priorityProperty = employee["Priority"];
-    Assert.Equal(Priority.High, priorityProperty.Value);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L239-L252' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-select-enum' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Checkbox
-
-Bind to boolean properties:
-
-<!-- snippet: blazor-checkbox-binding -->
-<a id='snippet-blazor-checkbox-binding'></a>
-```cs
-[Fact]
-public void CheckboxBindsToBooleanProperty()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    // Toggle boolean value
-    employee.IsActive = true;
-
-    var isActiveProperty = employee["IsActive"];
-    Assert.Equal(true, isActiveProperty.Value);
-
-    // Toggle again
-    employee.IsActive = false;
-    Assert.Equal(false, isActiveProperty.Value);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L254-L271' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-checkbox-binding' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Date Picker
-
-Bind to date properties:
-
-<!-- snippet: blazor-date-picker -->
-<a id='snippet-blazor-date-picker'></a>
-```cs
-[Fact]
-public void DatePickerBindsToDateProperty()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    var startDate = new DateTime(2024, 1, 15);
-    employee.StartDate = startDate;
-
-    var startDateProperty = employee["StartDate"];
-    Assert.Equal(startDate, startDateProperty.Value);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L273-L286' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-date-picker' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Numeric Fields
-
-Bind to numeric properties:
-
-<!-- snippet: blazor-numeric-field -->
-<a id='snippet-blazor-numeric-field'></a>
-```cs
-[Fact]
-public void NumericFieldBindsToDecimalProperty()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    employee.Salary = 75000.50m;
-
-    var salaryProperty = employee["Salary"];
-    Assert.Equal(75000.50m, salaryProperty.Value);
-
-    // Validation enforces range
-    employee.Salary = -1000;
-    Assert.False(salaryProperty.IsValid);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L288-L304' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-numeric-field' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Autocomplete
-
-Bind with autocomplete behavior:
-
-<!-- snippet: blazor-autocomplete -->
-<a id='snippet-blazor-autocomplete'></a>
-```cs
-[Fact]
-public void AutocompleteBindsToStringProperty()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    employee.Department = "Engineering";
-
-    var deptProperty = employee["Department"];
-    Assert.Equal("Engineering", deptProperty.Value);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L306-L318' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-autocomplete' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Change Tracking in UI
-
-React to property changes:
-
-<!-- snippet: blazor-change-tracking -->
-<a id='snippet-blazor-change-tracking'></a>
-```cs
-[Fact]
-public void ChangeTrackingDetectsModifications()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    // New entity starts unmodified
-    Assert.False(employee.IsSelfModified);
-
-    // Making changes sets IsModified
-    employee.Name = "Changed Name";
-    Assert.True(employee.IsSelfModified);
-    Assert.True(employee.IsModified);
-
-    // Track which properties changed
-    Assert.Contains("Name", employee.ModifiedProperties);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L320-L338' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-change-tracking' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Customizing Appearance
-
-Style based on validation state:
-
-<!-- snippet: blazor-customize-appearance -->
-<a id='snippet-blazor-customize-appearance'></a>
-```cs
-[Fact]
-public void ComponentAcceptsStyleParameters()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-
-    // Properties are accessible for binding
-    var nameProperty = employee["Name"];
-    Assert.NotNull(nameProperty.DisplayName);
-
-    // All MudBlazor parameters pass through to the underlying component
-    // (Variant, Margin, HelperText, Adornment, etc.)
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L340-L354' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-customize-appearance' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Property Extensions
-
-Access extended property information:
-
-<!-- snippet: blazor-property-extensions -->
-<a id='snippet-blazor-property-extensions'></a>
-```cs
-[Fact]
-public void ExtensionMethodsProvideValidationInfo()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-    employee.Email = "invalid";
-
-    var emailProperty = employee["Email"];
-
-    // Extension method pattern (simulated - actual extensions in Neatoo.Blazor.MudNeatoo)
-    var hasErrors = emailProperty.PropertyMessages.Any();
-    var errorText = string.Join("; ", emailProperty.PropertyMessages.Select(m => m.Message));
-
-    Assert.True(hasErrors);
-    Assert.NotEmpty(errorText);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L356-L373' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-property-extensions' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Manual State Updates
-
-Trigger UI updates manually:
-
-<!-- snippet: blazor-statehaschanged -->
-<a id='snippet-blazor-statehaschanged'></a>
-```cs
-[Fact]
-public void PropertyChangesNotifyComponents()
-{
-    var factory = GetRequiredService<IBlazorEmployeeFactory>();
-    var employee = factory.Create();
-    var nameProperty = employee["Name"];
-
-    var changedProperties = new List<string>();
-    nameProperty.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName ?? "");
-
-    // Setting value triggers PropertyChanged
-    employee.Name = "Test";
-
-    Assert.NotEmpty(changedProperties);
-}
-```
-<sup><a href='/src/samples/BlazorSamples.cs#L375-L391' title='Snippet source file'>snippet source</a> | <a href='#snippet-blazor-statehaschanged' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
 ## Manual Binding
 
-For custom controls without Neatoo components:
+For custom controls without MudNeatoo components, use `SetValue` for async property assignment:
 
 <!-- snippet: blazor-manual-binding -->
 <a id='snippet-blazor-manual-binding'></a>
@@ -438,12 +147,13 @@ public async Task ManualBindingUsesSetValueAsync()
 | `NeatooValidationSummary` | All validation errors |
 | `NeatooValidationMessage` | Single property validation |
 
+All MudBlazor parameters pass through to the underlying component (Variant, Margin, HelperText, Adornment, etc.).
+
 ## Best Practices
 
-1. **Use Neatoo components** - They handle validation and change tracking automatically
-2. **Bind to ViewModel properties** - Not directly to domain model
-3. **Handle IsBusy** - Disable buttons and show loading during async operations
-4. **Show validation early** - Display errors as user types, not just on submit
+1. **Use Neatoo components** — They handle validation display and change tracking automatically
+2. **Handle IsBusy** — Disable buttons and show loading during async operations
+3. **Show validation early** — Display errors as user types, not just on submit
 
 ## Blazor WASM Project Structure
 
@@ -494,6 +204,6 @@ This ensures:
 
 ## Related
 
-- [Validation](validation.md) - Validation rules and BrokenRules
+- [Validation](validation.md) - Validation rules
 - [Properties](properties.md) - Property change notifications
 - [Entities](entities.md) - IsSavable for submit buttons

--- a/skills/neatoo/references/entities.md
+++ b/skills/neatoo/references/entities.md
@@ -1,135 +1,6 @@
 # Entities
 
-`EntityBase<T>` provides the foundation for persistent entities with full CRUD lifecycle, change tracking, and save routing.
-
-## Basic Entity Definition
-
-Inherit from `EntityBase<T>` and add factory methods:
-
-<!-- snippet: entities-base-class -->
-<a id='snippet-entities-base-class'></a>
-```cs
-[Factory]
-public partial class EntitiesEmployee : EntityBase<EntitiesEmployee>
-{
-    public EntitiesEmployee(IEntityBaseServices<EntitiesEmployee> services) : base(services) { }
-
-    public partial int Id { get; set; }
-
-    public partial string Name { get; set; }
-
-    public partial string Email { get; set; }
-
-    public partial decimal Salary { get; set; }
-
-    [Create]
-    public void Create() { }
-}
-```
-<sup><a href='/src/samples/EntitiesSamples.cs#L15-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-base-class' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Aggregate Root Pattern
-
-Mark the root entity of an aggregate:
-
-<!-- snippet: entities-aggregate-root -->
-<a id='snippet-entities-aggregate-root'></a>
-```cs
-[Factory]
-public partial class EntitiesOrder : EntityBase<EntitiesOrder>
-{
-    public EntitiesOrder(IEntityBaseServices<EntitiesOrder> services) : base(services)
-    {
-        // Initialize the items collection
-        ItemsProperty.LoadValue(new EntitiesOrderItemList());
-    }
-
-    public partial int Id { get; set; }
-
-    public partial string OrderNumber { get; set; }
-
-    public partial DateTime OrderDate { get; set; }
-
-    // Child collection establishes aggregate boundary
-    public partial IEntitiesOrderItemList Items { get; set; }
-
-    // Expose protected methods for samples
-    public void DoMarkModified() => MarkModified();
-    public void DoMarkUnmodified() => MarkUnmodified();
-
-    [Create]
-    public void Create() { }
-
-    [Fetch]
-    public void Fetch(int id, string orderNumber, DateTime orderDate)
-    {
-        Id = id;
-        OrderNumber = orderNumber;
-        OrderDate = orderDate;
-    }
-}
-```
-<sup><a href='/src/samples/EntitiesSamples.cs#L108-L142' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-aggregate-root' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Factory Methods
-
-Define factory methods for Create, Fetch, and persistence:
-
-<!-- snippet: entities-factory-methods -->
-<a id='snippet-entities-factory-methods'></a>
-```cs
-[Factory]
-public partial class EntitiesCustomer : EntityBase<EntitiesCustomer>
-{
-    public EntitiesCustomer(IEntityBaseServices<EntitiesCustomer> services) : base(services) { }
-
-    public partial int Id { get; set; }
-
-    public partial string Name { get; set; }
-
-    public partial string Email { get; set; }
-
-    [Create]
-    public void Create()
-    {
-        // Initialize default values for new customer
-        Id = 0;
-        Name = "";
-        Email = "";
-    }
-
-    [Fetch]
-    public async Task FetchAsync(int id, [Service] IEntitiesCustomerRepository repository)
-    {
-        var data = await repository.FetchAsync(id);
-        Id = data.Id;
-        Name = data.Name;
-        Email = data.Email;
-    }
-
-    [Insert]
-    public async Task InsertAsync([Service] IEntitiesCustomerRepository repository)
-    {
-        await repository.InsertAsync(this);
-    }
-
-    [Update]
-    public async Task UpdateAsync([Service] IEntitiesCustomerRepository repository)
-    {
-        await repository.UpdateAsync(this);
-    }
-
-    [Delete]
-    public async Task DeleteAsync([Service] IEntitiesCustomerRepository repository)
-    {
-        await repository.DeleteAsync(this);
-    }
-}
-```
-<sup><a href='/src/samples/EntitiesSamples.cs#L147-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-methods' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
+`EntityBase<T>` provides the foundation for persistent entities with full CRUD lifecycle, change tracking, and save routing. For base class definitions and factory method examples, see [base-classes.md](base-classes.md).
 
 ## Entity Lifecycle
 
@@ -150,7 +21,7 @@ public void IsNew_DistinguishesNewFromExisting()
     Assert.True(order.IsNew);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L223-L233' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-is-new' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L391-L401' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-is-new' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 <!-- snippet: entities-lifecycle-new -->
 <!-- endSnippet -->
@@ -177,7 +48,7 @@ public async Task FetchedEntity_StartsClean()
     Assert.Equal("Customer 42", customer.Name);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L255-L270' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-fetch' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L423-L438' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-fetch' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Saving Entities
@@ -202,7 +73,7 @@ public async Task Save_DelegatesToAppropriateFactoryMethod()
     Assert.True(employee.IsSavable);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L272-L287' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L440-L455' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Save Routing:**
@@ -237,7 +108,7 @@ public async Task Delete_MarksEntityForDeletion()
     Assert.True(customer.IsSavable);  // Ready for delete operation
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L289-L309' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-delete' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L457-L477' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-delete' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Undeleting Entities
@@ -268,7 +139,7 @@ public async Task UnDelete_ReversesDeleteBeforeSave()
     Assert.False(customer.IsModified); // Back to clean state
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L311-L332' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-undelete' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L479-L500' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-undelete' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Change Tracking
@@ -305,7 +176,7 @@ public void ModificationState_TracksChanges()
     Assert.Contains("OrderNumber", order.ModifiedProperties);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L364-L389' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-modification-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L532-L557' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-modification-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Marking Clean/Dirty
@@ -334,7 +205,7 @@ public void MarkModified_ForcesEntityToBeSaved()
     Assert.True(order.IsMarkedModified);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L391-L410' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-mark-modified' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L559-L578' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-mark-modified' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 <!-- snippet: entities-mark-unmodified -->
 <!-- endSnippet -->
@@ -371,7 +242,7 @@ public async Task PersistenceState_DeterminesFactoryMethod()
     Assert.False(fetchedOrder.IsDeleted);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L436-L461' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-persistence-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L604-L629' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-persistence-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## IsSavable
@@ -404,7 +275,7 @@ public void IsSavable_CombinesStateChecks()
     Assert.True(order.IsSavable);     // Can save!
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L463-L486' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L631-L654' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `IsSavable` returns `true` when:
@@ -447,7 +318,7 @@ public async Task ChildEntity_CannotSaveDirectly()
     Assert.Equal(SaveFailureReason.IsChildObject, exception.Reason);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L488-L516' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L656-L684' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Factory Services
@@ -472,7 +343,7 @@ public void Factory_SetThroughDependencyInjection()
     // The factory calls Insert, Update, or Delete based on entity state
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L518-L533' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L686-L701' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Save Cancellation
@@ -502,7 +373,7 @@ public async Task Save_SupportsCancellation()
     Assert.True(order.IsModified);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L535-L555' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L703-L723' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Parent Property
@@ -540,8 +411,246 @@ public void Parent_EstablishesAggregateGraph()
     Assert.Null(order.Root);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L334-L362' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-parent-property' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L502-L530' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-parent-property' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Aggregate Save Cascading
+
+Understanding how saves propagate through an aggregate hierarchy is critical. Neatoo handles state cascading and save cascading differently.
+
+### State Cascades UP Automatically
+
+The framework automatically propagates `IsModified`, `IsValid`, and `IsBusy` up the object graph. When a child becomes modified, its parent's `IsModified` becomes true. This is framework behavior — you don't write code for it.
+
+```
+Grandchild.Name = "new"  →  Grandchild.IsModified = true
+                          →  Child.IsModified = true      (automatic)
+                          →  Root.IsModified = true        (automatic)
+```
+
+### Saves Cascade DOWN Manually
+
+**The framework does NOT auto-save children.** When `factory.SaveAsync(root)` is called, it routes to the root's `[Insert]` or `[Update]` method. That method must explicitly save each child. Those children's `[Insert]`/`[Update]` must save their children, and so on.
+
+```
+External code calls:     factory.SaveAsync(order)
+                              ↓  (routes to Insert or Update based on IsNew)
+Order [Insert]:          saves each OrderItem via itemFactory.SaveAsync(item, orderId)
+                              ↓  (routes to Insert or Update based on IsNew)
+OrderItem [Insert]:      saves each Detail via detailFactory.SaveAsync(detail, itemId)
+```
+
+### The Insert Pattern
+
+Each entity's `[Insert]` saves this entity first (to get the ID), then saves its direct children:
+
+<!-- snippet: entities-cascade-insert -->
+<a id='snippet-entities-cascade-insert'></a>
+```cs
+[Factory]
+public partial class EntitiesCascadeOrder : EntityBase<EntitiesCascadeOrder>
+{
+    public EntitiesCascadeOrder(IEntityBaseServices<EntitiesCascadeOrder> services) : base(services)
+    {
+        ItemsProperty.LoadValue(new EntitiesCascadeItemList());
+    }
+
+    public partial int Id { get; set; }
+    public partial string OrderNumber { get; set; }
+    public partial EntitiesCascadeItemList Items { get; set; }
+
+    [Create]
+    public void Create() { }
+
+    [Fetch]
+    public void Fetch(int id, string orderNumber)
+    {
+        Id = id;
+        OrderNumber = orderNumber;
+    }
+
+    [Insert]
+    public async Task InsertAsync(
+        [Service] IEntitiesCascadeOrderRepository repository,
+        [Service] IEntitiesCascadeItemFactory itemFactory)
+    {
+        // 1. Save this entity first (get the ID)
+        Id = await repository.InsertOrderAsync(OrderNumber);
+
+        // 2. Save children — parent is responsible for calling childFactory.Save()
+        for (int i = 0; i < Items.Count; i++)
+        {
+            Items[i] = await itemFactory.SaveAsync(Items[i], Id);
+        }
+    }
+```
+<sup><a href='/src/samples/EntitiesSamples.cs#L289-L326' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-cascade-insert' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+### The Update Pattern
+
+The `[Update]` has three parts: save this entity, save active children (new or modified), and save deleted children:
+
+<!-- snippet: entities-cascade-update -->
+<a id='snippet-entities-cascade-update'></a>
+```cs
+[Update]
+public async Task UpdateAsync(
+    [Service] IEntitiesCascadeOrderRepository repository,
+    [Service] IEntitiesCascadeItemFactory itemFactory)
+{
+    // 1. Update this entity
+    await repository.UpdateOrderAsync(Id, OrderNumber);
+
+    // 2. Save active children — routes to child's [Insert] or [Update]
+    for (int i = 0; i < Items.Count; i++)
+    {
+        if (Items[i].IsNew)
+        {
+            Items[i] = await itemFactory.SaveAsync(Items[i], Id);
+        }
+        else if (Items[i].IsModified)
+        {
+            Items[i] = (await itemFactory.SaveAsync(Items[i]))!;
+        }
+    }
+
+    // 3. Save deleted children — routes to child's [Delete]
+    foreach (var deleted in Items.Deleted)
+    {
+        await itemFactory.SaveAsync(deleted);
+    }
+}
+```
+<sup><a href='/src/samples/EntitiesSamples.cs#L328-L356' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-cascade-update' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+**Key:** Each child's own `[Insert]`/`[Update]`/`[Delete]` handles its persistence logic (mapping to EF entities, calling repository methods). The parent only calls `itemFactory.SaveAsync()`.
+
+External code only saves the aggregate root:
+
+<!-- snippet: entities-cascade-correct-external -->
+<a id='snippet-entities-cascade-correct-external'></a>
+```cs
+[Fact]
+public async Task CascadeSave_OnlyRootSavedExternally()
+{
+    var orderFactory = GetRequiredService<IEntitiesCascadeOrderFactory>();
+    var itemFactory = GetRequiredService<IEntitiesCascadeItemFactory>();
+
+    var order = orderFactory.Create();
+    order.OrderNumber = "ORD-001";
+
+    var item = itemFactory.Create();
+    item.ProductName = "Widget";
+    item.Quantity = 5;
+    order.Items.Add(item);
+
+    // CORRECT: only save the aggregate root from external code
+    // order.Insert calls itemFactory.SaveAsync for each child
+    var saved = (await orderFactory.SaveAsync(order))!;
+
+    Assert.False(saved.IsNew);
+}
+```
+<sup><a href='/src/samples/EntitiesSamples.cs#L798-L819' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-cascade-correct-external' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+### Rules
+
+1. **Only the aggregate root is saved externally** — external code calls `factory.SaveAsync(root)`, never `factory.SaveAsync(child)`
+2. **Each entity saves its own direct children** — don't skip levels (root should not save grandchildren)
+3. **Save order matters** — parent must be inserted before children (to get the parent ID)
+4. **Reassign after save** — `factory.SaveAsync()` returns a new instance, so always reassign: `Items[i] = await itemFactory.SaveAsync(Items[i])`
+
+### Anti-Pattern: Flat Save
+
+Do NOT save entities from a flat coordinator that reaches into the hierarchy:
+
+```csharp
+// WRONG — bypasses aggregate cascade
+async Task SaveEverything()
+{
+    await consultationFactory.SaveAsync(consultation);  // saves its visits
+    await visitFactory.SaveAsync(visit);                // WRONG: already saved by consultation
+    await treatmentFactory.SaveAsync(treatment);        // WRONG: should be saved by visit
+}
+```
+
+Instead, each level saves its own children:
+
+```csharp
+// CORRECT — each entity saves its direct children in [Insert]/[Update]
+// Consultation.Insert → saves Visit via visitFactory.SaveAsync
+// Visit.Insert → saves Treatment via treatmentFactory.SaveAsync
+// External code only calls: await consultationFactory.SaveAsync(consultation)
+```
+
+### Anti-Pattern: Parent Does Child's Persistence Inline
+
+Do NOT put child persistence logic (EF entity mapping, repository calls) in the parent's `[Insert]`/`[Update]`. Each child handles its own persistence in its own factory methods.
+
+```csharp
+// WRONG — parent manually persists children instead of delegating
+[Update]
+public async Task UpdateAsync([Service] IAssessmentRepository repository)
+{
+    var entity = await repository.GetByIdAsync(this.Id);
+    MapTo(entity);
+
+    // BAD: parent iterates children and does their persistence work
+    foreach (var area in AreasList)
+    {
+        var areaEntity = entity.Areas.FirstOrDefault(a => a.LocationId == area.LocationId);
+        if (areaEntity != null)
+        {
+            areaEntity.Value = area.Value?.ToString();  // parent maps child properties
+        }
+        else
+        {
+            await repository.InsertAreaAsync(new AreaEntity  // parent creates child EF entities
+            {
+                AssessmentId = this.Id,
+                Value = area.Value?.ToString()
+            });
+        }
+    }
+}
+```
+
+```csharp
+// CORRECT — parent delegates to child factory; child handles its own persistence
+[Update]
+public async Task UpdateAsync([Service] IAssessmentRepository repository,
+    [Service] IAreaFactory areaFactory)
+{
+    var entity = await repository.GetByIdAsync(this.Id);
+    MapTo(entity);
+
+    // Each child's [Insert]/[Update]/[Delete] handles its own EF mapping
+    for (int i = 0; i < AreasList.Count; i++)
+    {
+        if (AreasList[i].IsNew)
+        {
+            AreasList[i] = await areaFactory.SaveAsync(AreasList[i], this.Id);
+        }
+        else if (AreasList[i].IsModified)
+        {
+            AreasList[i] = (await areaFactory.SaveAsync(AreasList[i]))!;
+        }
+    }
+
+    foreach (var deleted in AreasList.DeletedList)
+    {
+        await areaFactory.SaveAsync(deleted);
+    }
+}
+```
+
+**Why this matters:** When the parent does the child's persistence inline, the child's `[Insert]`/`[Update]`/`[Delete]` methods don't exist or go unused. This means:
+- Child persistence logic can't be tested independently
+- Conditional persistence decisions (e.g., skip empty children) get tangled into the parent
+- The parent grows large and complex as the child's schema evolves
 
 ## Related
 

--- a/skills/neatoo/references/pitfalls.md
+++ b/skills/neatoo/references/pitfalls.md
@@ -10,190 +10,14 @@ This document captures important patterns and behaviors when working with Neatoo
 | Calling `Save()` on child entities | Child entities don't save independently—they're saved with their aggregate root | Call `Save()` only on the aggregate root |
 | Missing `partial` keyword on class | Source generator won't generate factory methods | Add `partial` to class declaration |
 | Missing `partial` keyword on properties | Source generator won't implement change tracking | Add `partial` to property declarations |
+| Non-partial properties on domain models | **Data silently lost during client-server JSON serialization round-trip.** Properties appear to work locally but values are zero/null after Neatoo's serialization (e.g., after `Save()` or factory `Fetch()`). This is especially insidious because there's no error — values just disappear. | Make ALL domain model properties that need to survive serialization `partial`. Also note: `partial` properties cannot have default initializers — set defaults in `Create()` or `MapFrom()` instead. |
 | Constructor injection for server-only services | Service unavailable on client causes DI failure | Use method injection (`[Service]` on method parameter) for server-only services |
 | Adding `[Remote]` to child entity factory methods | Unnecessary—child methods are called from server | Only use `[Remote]` on aggregate root entry points |
 | Expecting new items in DeletedList after remove | New items (IsNew=true) are removed entirely—nothing to delete from DB | Only existing items go to DeletedList |
 | Moving entities between aggregates directly | Throws `InvalidOperationException`—item.Root must match list.Root | Remove → Save → Re-fetch/create → Add to new aggregate |
+| Parent maps child properties to EF entities inline | Child has no `[Insert]`/`[Update]`/`[Delete]`; persistence logic is untestable and tangled into parent | Parent calls `childFactory.SaveAsync(child)` — child handles its own EF mapping in its own factory methods |
+| Forgetting to iterate DeletedList in parent's `[Update]` | Removed children are never deleted from the database | After saving active children, iterate `ChildList.DeletedList` and call `childFactory.SaveAsync(deleted)` for each |
 | Forgetting items are modified when added to collections | Adding a fetched (non-new) item marks both item and list as `IsModified` | Expected behavior—adding to a new parent is a state change |
-
----
-
-## Commands
-
-Commands are static partial classes with `[Factory]` and `[Execute]` methods:
-
-```csharp
-[Factory]
-public static partial class SendEmailCommand
-{
-    [Execute]
-    internal static async Task<bool> _SendEmail(
-        string to,
-        string subject,
-        string body,
-        [Service] IEmailService emailService)
-    {
-        await emailService.SendAsync(to, subject, body);
-        return true;
-    }
-}
-```
-
-The source generator creates a delegate (`SendEmailCommand.SendEmail`) that you inject via DI.
-
----
-
-## Read-Only Patterns
-
-Use `ValidateBase` with only `[Fetch]` methods (no `[Insert]`/`[Update]`/`[Delete]`):
-
-```csharp
-[Factory]
-public partial class EmployeeSummary : ValidateBase<EmployeeSummary>
-{
-    public EmployeeSummary(IValidateBaseServices<EmployeeSummary> services) : base(services) { }
-
-    public partial int Id { get; set; }
-    public partial string Name { get; set; }
-
-    // Fetch-only = effectively read-only
-    [Fetch]
-    public void Fetch(int id, string name)
-    {
-        Id = id;
-        Name = name;
-    }
-}
-
-public class EmployeeSummaryList : ValidateListBase<EmployeeSummary> { }
-```
-
----
-
-## Authorization
-
-Use a single `[AuthorizeFactory<>]` attribute with a combined interface:
-
-```csharp
-public interface ISecureEntityAuthorization
-{
-    [AuthorizeFactory(AuthorizeFactoryOperation.Fetch)]
-    bool CanFetch();
-
-    [AuthorizeFactory(AuthorizeFactoryOperation.Write)]
-    bool CanSave();
-}
-
-public class SecureEntityAuthorization : ISecureEntityAuthorization
-{
-    private readonly IPrincipal _principal;
-    private readonly IFeatureFlagService _featureFlags;
-
-    public SecureEntityAuthorization(IPrincipal principal, IFeatureFlagService featureFlags)
-    {
-        _principal = principal;
-        _featureFlags = featureFlags;
-    }
-
-    // Combine multiple checks in one method
-    public bool CanFetch()
-    {
-        var isAuthenticated = _principal.Identity?.IsAuthenticated ?? false;
-        var featureEnabled = _featureFlags.IsEnabled("SecureEntityAccess");
-        return isAuthenticated && featureEnabled;
-    }
-
-    public bool CanSave() => _principal.IsInRole("Admin");
-}
-
-[Factory]
-[AuthorizeFactory<ISecureEntityAuthorization>]
-public partial class SecureEntity : EntityBase<SecureEntity>
-```
-
----
-
-## NeatooPropertyChanged Event
-
-Use single argument (event args) and return Task:
-
-```csharp
-entity.NeatooPropertyChanged += (e) =>
-{
-    Console.WriteLine(e.PropertyName);
-    return Task.CompletedTask;
-};
-```
-
----
-
-## ChangeReason
-
-Use `Reason` property with `Load` or `UserEdit` values:
-
-```csharp
-var reason = e.Reason;
-Assert.AreEqual(ChangeReason.Load, reason);
-```
-
-The `ChangeReason` enum has two values:
-- `ChangeReason.UserEdit` - Normal property setter assignment
-- `ChangeReason.Load` - Data loading via `LoadValue()`
-
----
-
-## Project Configuration
-
-Include generator references with proper configuration:
-
-```xml
-<PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
-</PropertyGroup>
-
-<ItemGroup>
-    <!-- Analyzers as separate references -->
-    <ProjectReference Include="path/to/Neatoo.BaseGenerator.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
-    <ProjectReference Include="path/to/Neatoo.Analyzers.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
-
-    <!-- Main Neatoo reference -->
-    <ProjectReference Include="path/to/Neatoo.csproj" />
-
-    <!-- Exclude generated files from compilation (already included by generator) -->
-    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
-</ItemGroup>
-```
-
----
-
-## Validation Rules Are Async
-
-Await `RunRules()` before checking validity:
-
-```csharp
-employee.Name = "";
-await employee.RunRules(RunRulesFlag.All);
-Assert.IsFalse(employee["Name"].IsValid);
-```
-
----
-
-## Testing
-
-Use real Neatoo factories and mock only external dependencies:
-
-```csharp
-services.AddNeatooServices(NeatooFactory.Logical, typeof(Employee).Assembly);
-services.AddScoped<IEmployeeRepository, MockEmployeeRepository>();
-
-var factory = serviceProvider.GetRequiredService<IEmployeeFactory>();
-var employee = factory.Create();  // Real Neatoo object
-```
 
 ---
 
@@ -201,14 +25,12 @@ var employee = factory.Create();  // Real Neatoo object
 
 | Pattern | How To |
 |---------|--------|
-| Commands | Static class with `[Factory]` and `[Execute]` |
-| Read-only models | `ValidateBase` with only `[Fetch]` methods |
-| Authorization | Single `[AuthorizeFactory<IInterface>]` attribute |
-| Property change events | `(e) => { return Task.CompletedTask; }` |
-| Change reason property | `e.Reason` |
-| Change reason for loads | `ChangeReason.Load` |
-| Check validity | `await RunRules()` first |
-| Testing | Use real factories, mock external deps |
+| Commands | Static class with `[Factory]` and `[Execute]` — see [base-classes.md](base-classes.md) |
+| Read-only models | `ValidateBase` with only `[Fetch]` methods — see [base-classes.md](base-classes.md) |
+| Authorization | Single `[AuthorizeFactory<IInterface>]` attribute — see `/RemoteFactory` skill |
+| Property change events | `(e) => { return Task.CompletedTask; }` — see [properties.md](properties.md) |
+| Check validity | `await RunRules()` first — see [validation.md](validation.md) |
+| Testing | Use real factories, mock external deps — see [testing.md](testing.md) |
 | Remove new item | Gone entirely (not in DeletedList) |
 | Remove existing item | Goes to DeletedList, `IsDeleted = true` |
 | Re-add removed item | Removed from DeletedList, `UnDelete()` called |

--- a/skills/neatoo/references/testing.md
+++ b/skills/neatoo/references/testing.md
@@ -2,9 +2,9 @@
 
 Testing Neatoo domain models requires a specific approach: **never mock Neatoo interfaces or classes**. Use real Neatoo objects to ensure your tests validate actual framework behavior.
 
-## Core Testing Principle
+## Core Principle
 
-**DO:** Use real Neatoo classes
+**DO:** Use real Neatoo classes and factories
 **DON'T:** Mock Neatoo interfaces or implement stubs
 
 <!-- snippet: test-real-vs-mock -->
@@ -40,422 +40,14 @@ public async Task RealVsMock_UseRealNeatooClasses()
 <sup><a href='/src/samples/TestingPatternsTests.cs#L46-L73' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-real-vs-mock' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-## Why No Mocking?
+**Why no mocking:**
+1. Neatoo classes work together as a cohesive unit — mocking breaks this
+2. Mocks test your mock setup, not actual Neatoo behavior
+3. Real objects reveal integration issues that mocks hide
 
-1. **Cohesive behavior** - Neatoo classes work together; mocking breaks this
-2. **Test real behavior** - Mocks test your mock setup, not Neatoo
-3. **Catch integration issues** - Real objects reveal actual problems
-4. **Framework guarantees** - Neatoo's behavior is the specification
+## Test Base Class Setup
 
-## Test Project Setup
-
-<!-- snippet: test-project-setup -->
-<a id='snippet-test-project-setup'></a>
-```cs
-// Test project setup requirements:
-//
-// 1. Add project references:
-//    - Reference to domain project (where Neatoo entities are)
-//    - Reference to Neatoo NuGet package
-//
-// 2. Register services:
-//    services.AddNeatooServices(NeatooFactory.Logical, typeof(MyEntity).Assembly);
-//
-// 3. Mock EXTERNAL dependencies, not Neatoo classes:
-//    services.AddScoped<IMyRepository, MockMyRepository>();
-//
-// 4. Use real Neatoo factories:
-//    var factory = GetRequiredService<IEmployeeFactory>();
-//    var employee = factory.Create();
-//
-// NeatooFactory.Logical means all factory operations run locally
-// (no HTTP calls to remote server)
-```
-<sup><a href='/src/samples/SkillTestBase.cs#L113-L132' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-project-setup' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Testing Validation
-
-Test validation rules with real objects:
-
-<!-- snippet: test-validation -->
-<a id='snippet-test-validation'></a>
-```cs
-/// <summary>
-/// Test validation rules with real Neatoo validation.
-/// </summary>
-[Fact]
-public async Task Validation_TestsRealRules()
-{
-    var factory = GetRequiredService<ISkillValidProductFactory>();
-    var product = factory.Create();
-
-    // Test invalid state
-    product.Name = "";
-    product.Price = -10;
-
-    await product.RunRules();
-
-    Assert.False(product.IsValid);
-    Assert.False(product["Name"].IsValid);
-    Assert.False(product["Price"].IsValid);
-
-    // Test valid state
-    product.Name = "Widget";
-    product.Price = 19.99m;
-
-    await product.RunRules();
-
-    Assert.True(product.IsValid);
-    Assert.True(product["Name"].IsValid);
-    Assert.True(product["Price"].IsValid);
-}
-
-/// <summary>
-/// Test DataAnnotation validation attributes.
-/// </summary>
-[Fact]
-public void ValidationAttributes_AutoConverted()
-{
-    var factory = GetRequiredService<ISkillValidRegistrationFactory>();
-    var reg = factory.Create();
-
-    // [Required] - empty fails
-    reg.Username = "";
-    Assert.False(reg["Username"].IsValid);
-
-    reg.Username = "validuser";
-    Assert.True(reg["Username"].IsValid);
-
-    // [EmailAddress] - invalid format fails
-    reg.Email = "not-an-email";
-    Assert.False(reg["Email"].IsValid);
-
-    reg.Email = "valid@example.com";
-    Assert.True(reg["Email"].IsValid);
-
-    // [Range] - out of range fails
-    reg.Age = 10;
-    Assert.False(reg["Age"].IsValid);
-
-    reg.Age = 25;
-    Assert.True(reg["Age"].IsValid);
-}
-```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L79-L140' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-validation' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Testing Change Tracking
-
-Verify change tracking behavior:
-
-<!-- snippet: test-change-tracking -->
-<a id='snippet-test-change-tracking'></a>
-```cs
-/// <summary>
-/// Test change tracking with real Neatoo entities.
-/// </summary>
-[Fact]
-public void ChangeTracking_DetectsPropertyChanges()
-{
-    var factory = GetRequiredService<ISkillEntityEmployeeFactory>();
-
-    // Fetch creates an existing (non-new) entity
-    var employee = factory.Fetch(1, "Alice", "Engineering", 50000);
-
-    // After fetch, entity is clean
-    Assert.False(employee.IsNew);
-    Assert.False(employee.IsModified);
-    Assert.False(employee.IsSelfModified);
-
-    // Change a property
-    employee.Name = "Alice Smith";
-
-    // Now entity tracks the change
-    Assert.True(employee.IsModified);
-    Assert.True(employee.IsSelfModified);
-    Assert.True(employee.ModifiedProperties.Contains("Name"));
-
-    // Other properties not tracked
-    Assert.False(employee.ModifiedProperties.Contains("Department"));
-
-    // Change another property
-    employee.Salary = 55000;
-    Assert.True(employee.ModifiedProperties.Contains("Salary"));
-}
-
-/// <summary>
-/// Test IsNew state after Create and Fetch.
-/// </summary>
-[Fact]
-public void ChangeTracking_IsNewState()
-{
-    var factory = GetRequiredService<ISkillEntityEmployeeFactory>();
-
-    // Create produces new entity
-    var newEmployee = factory.Create();
-    Assert.True(newEmployee.IsNew);
-
-    // Fetch produces existing entity
-    var existingEmployee = factory.Fetch(1, "Bob", "Sales", 60000);
-    Assert.False(existingEmployee.IsNew);
-}
-```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L146-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-change-tracking' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Testing Factory Methods
-
-Test factory operations:
-
-<!-- snippet: test-factory-methods -->
-<a id='snippet-test-factory-methods'></a>
-```cs
-/// <summary>
-/// Test factory methods with real factories.
-/// </summary>
-[Fact]
-public async Task FactoryMethods_TestCreateFetchSave()
-{
-    var factory = GetRequiredService<ISkillFactoryCustomerFactory>();
-
-    // Test Create
-    var customer = factory.Create();
-    Assert.True(customer.IsNew);
-    Assert.Equal(0, customer.Id);
-    Assert.Equal("", customer.Name);
-
-    // Test Fetch
-    var existing = await factory.FetchByIdAsync(1);
-    Assert.False(existing.IsNew);
-    Assert.Equal(1, existing.Id);
-    Assert.Equal("Customer 1", existing.Name);
-
-    // Test Save (routes to Insert for new entity)
-    customer.Name = "New Customer";
-    customer.Email = "new@example.com";
-    var saved = await factory.SaveAsync(customer);
-
-    Assert.NotNull(saved);
-    Assert.False(saved!.IsNew); // After insert, no longer new
-}
-
-/// <summary>
-/// Test multiple fetch overloads.
-/// </summary>
-[Fact]
-public async Task FactoryMethods_MultipleFetchOverloads()
-{
-    var factory = GetRequiredService<ISkillFactoryOrderFactory>();
-
-    // Fetch by ID
-    var byId = factory.FetchById(42);
-    Assert.Equal(42, byId.Id);
-
-    // Fetch by order number
-    var byNumber = factory.FetchByOrderNumber("ORD-00001");
-    Assert.Equal("ORD-00001", byNumber.OrderNumber);
-
-    // Fetch by customer email
-    var byCustomer = await factory.FetchByCustomerAsync("test@example.com");
-    Assert.Equal("test@example.com", byCustomer.CustomerEmail);
-}
-```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L201-L251' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-factory-methods' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Testing with Mocked Dependencies
-
-Mock external dependencies, not Neatoo:
-
-<!-- snippet: test-mock-dependencies -->
-<a id='snippet-test-mock-dependencies'></a>
-```cs
-/// <summary>
-/// Mock external dependencies, not Neatoo classes.
-/// </summary>
-[Fact]
-public async Task MockDependencies_OnlyMockExternal()
-{
-    // Mock repository is registered in SkillTestBase
-    // It provides fake data for fetch operations
-
-    var factory = GetRequiredService<ISkillGenEntityFactory>();
-
-    // Factory uses mock repository but REAL Neatoo entity
-    var entity = await factory.FetchAsync(1);
-
-    // Entity has real Neatoo behavior
-    Assert.False(entity.IsNew); // Real lifecycle
-    Assert.False(entity.IsModified); // Real tracking
-
-    // Mock provided the data
-    Assert.Equal(1, entity.Id);
-    Assert.Equal("Entity 1", entity.Name);
-
-    // Modify to test change detection
-    entity.Name = "Changed";
-    Assert.True(entity.IsModified); // Real change detection
-    Assert.Equal("Changed", entity.Name);
-}
-```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L257-L285' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-mock-dependencies' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Testing Collections
-
-Test collection behavior:
-
-<!-- snippet: test-collections -->
-<a id='snippet-test-collections'></a>
-```cs
-/// <summary>
-/// Test collection behavior with real Neatoo lists.
-/// </summary>
-[Fact]
-public void Collections_TestRealBehavior()
-{
-    var orderFactory = GetRequiredService<ISkillCollOrderFactory>();
-    var itemFactory = GetRequiredService<ISkillCollOrderItemFactory>();
-
-    var order = orderFactory.Create();
-
-    // Add items
-    var item1 = itemFactory.Create();
-    item1.ProductCode = "ITEM-001";
-    item1.Price = 19.99m;
-    item1.Quantity = 2;
-
-    var item2 = itemFactory.Create();
-    item2.ProductCode = "ITEM-002";
-    item2.Price = 29.99m;
-    item2.Quantity = 1;
-
-    order.Items.Add(item1);
-    order.Items.Add(item2);
-
-    // Real collection behavior
-    Assert.Equal(2, order.Items.Count);
-    Assert.True(item1.IsChild);
-    Assert.Same(order, item1.Parent);
-
-    // Remove item
-    order.Items.Remove(item1);
-    Assert.Equal(1, order.Items.Count);
-    Assert.Equal(0, order.Items.DeletedCount); // New item not tracked
-}
-
-/// <summary>
-/// Test deletion tracking for existing items.
-/// </summary>
-[Fact]
-public void Collections_DeletionTracking()
-{
-    var orderFactory = GetRequiredService<ISkillCollOrderFactory>();
-    var itemFactory = GetRequiredService<ISkillCollOrderItemFactory>();
-
-    var order = orderFactory.Create();
-
-    // Add "existing" item (via Fetch)
-    var item = itemFactory.Fetch(1, "WIDGET-001", 19.99m, 1);
-    order.Items.Add(item);
-    order.DoMarkUnmodified(); // Simulate loaded from DB
-
-    Assert.False(item.IsNew);
-
-    // Remove existing item
-    order.Items.Remove(item);
-
-    // Item tracked for deletion
-    Assert.True(item.IsDeleted);
-    Assert.Equal(1, order.Items.DeletedCount);
-}
-```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L291-L353' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-collections' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Testing Parent-Child Relationships
-
-Verify parent references:
-
-<!-- snippet: test-parent-child -->
-<a id='snippet-test-parent-child'></a>
-```cs
-/// <summary>
-/// Test parent-child relationships.
-/// </summary>
-[Fact]
-public void ParentChild_TracksRelationships()
-{
-    var deptFactory = GetRequiredService<ISkillEntityDepartmentFactory>();
-    var memberFactory = GetRequiredService<ISkillEntityDepartmentMemberFactory>();
-
-    var dept = deptFactory.Create();
-    dept.Name = "Engineering";
-
-    var member = memberFactory.Create();
-    member.Name = "Alice";
-    member.Role = "Developer";
-
-    // Before adding - no parent
-    Assert.Null(member.Parent);
-    Assert.False(member.IsChild);
-
-    // Add to collection
-    dept.Members.Add(member);
-
-    // After adding - parent established
-    Assert.Same(dept, member.Parent);
-    Assert.True(member.IsChild);
-
-    // Root walks to aggregate root
-    Assert.Same(dept, member.Root);
-    Assert.Null(dept.Root); // Root has no parent
-}
-```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L359-L391' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-parent-child' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Testing Async Rules
-
-Test async validation:
-
-<!-- snippet: test-async-rules -->
-<a id='snippet-test-async-rules'></a>
-```cs
-/// <summary>
-/// Test async validation rules.
-/// </summary>
-[Fact]
-public async Task AsyncRules_WaitForCompletion()
-{
-    var factory = GetRequiredService<ISkillValidUserFactory>();
-    var user = factory.Create();
-
-    user.Username = "testuser";
-
-    // Set email that will trigger async validation
-    user.Email = "taken@example.com"; // Mock returns false for "taken"
-
-    // Wait for async validation
-    await user.WaitForTasks();
-
-    // Async rule executed
-    Assert.False(user["Email"].IsValid);
-
-    // Change to valid email
-    user.Email = "available@example.com";
-    await user.WaitForTasks();
-
-    Assert.True(user["Email"].IsValid);
-}
-```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L397-L424' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-async-rules' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Integration Test Base Class
-
-Create a base class for common setup:
+Register Neatoo services with `NeatooFactory.Logical` (all operations run locally, no HTTP calls) and mock only external dependencies:
 
 <!-- snippet: test-base-class -->
 <a id='snippet-test-base-class'></a>
@@ -564,69 +156,134 @@ public abstract class SkillTestBase : IDisposable
 <sup><a href='/src/samples/SkillTestBase.cs#L10-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-base-class' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-## Testing Authorization
+## Testing Validation
 
-Test authorization separately:
-
-<!-- snippet: test-authorization -->
-<a id='snippet-test-authorization'></a>
+<!-- snippet: test-validation -->
+<a id='snippet-test-validation'></a>
 ```cs
 /// <summary>
-/// Test authorization logic separately from entity behavior.
+/// Test validation rules with real Neatoo validation.
 /// </summary>
 [Fact]
-public void Authorization_TestSeparately()
+public async Task Validation_TestsRealRules()
 {
-    // Test authorization implementation directly
-    var principal = new System.Security.Principal.GenericPrincipal(
-        new System.Security.Principal.GenericIdentity("testuser"),
-        new[] { "Admin" });
+    var factory = GetRequiredService<ISkillValidProductFactory>();
+    var product = factory.Create();
 
-    var auth = new SkillEmployeeAuthorization(principal);
+    // Test invalid state
+    product.Name = "";
+    product.Price = -10;
 
-    // Admin can create
-    Assert.True(auth.CanCreate());
-    Assert.True(auth.CanFetch());
-    Assert.True(auth.CanSave());
-    Assert.True(auth.CanDelete());
+    await product.RunRules();
 
-    // Non-admin limited
-    var limitedPrincipal = new System.Security.Principal.GenericPrincipal(
-        new System.Security.Principal.GenericIdentity("viewer"),
-        new[] { "Viewer" });
+    Assert.False(product.IsValid);
+    Assert.False(product["Name"].IsValid);
+    Assert.False(product["Price"].IsValid);
 
-    var limitedAuth = new SkillEmployeeAuthorization(limitedPrincipal);
+    // Test valid state
+    product.Name = "Widget";
+    product.Price = 19.99m;
 
-    Assert.False(limitedAuth.CanCreate());
-    Assert.True(limitedAuth.CanFetch()); // Authenticated
-    Assert.False(limitedAuth.CanSave());
-    Assert.False(limitedAuth.CanDelete());
+    await product.RunRules();
+
+    Assert.True(product.IsValid);
+    Assert.True(product["Name"].IsValid);
+    Assert.True(product["Price"].IsValid);
+}
+
+/// <summary>
+/// Test DataAnnotation validation attributes.
+/// </summary>
+[Fact]
+public void ValidationAttributes_AutoConverted()
+{
+    var factory = GetRequiredService<ISkillValidRegistrationFactory>();
+    var reg = factory.Create();
+
+    // [Required] - empty fails
+    reg.Username = "";
+    Assert.False(reg["Username"].IsValid);
+
+    reg.Username = "validuser";
+    Assert.True(reg["Username"].IsValid);
+
+    // [EmailAddress] - invalid format fails
+    reg.Email = "not-an-email";
+    Assert.False(reg["Email"].IsValid);
+
+    reg.Email = "valid@example.com";
+    Assert.True(reg["Email"].IsValid);
+
+    // [Range] - out of range fails
+    reg.Age = 10;
+    Assert.False(reg["Age"].IsValid);
+
+    reg.Age = 25;
+    Assert.True(reg["Age"].IsValid);
 }
 ```
-<sup><a href='/src/samples/TestingPatternsTests.cs#L430-L462' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-authorization' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/TestingPatternsTests.cs#L79-L140' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-validation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-## Test Organization
+## Testing Change Tracking
 
-Organize tests by behavior:
+<!-- snippet: test-change-tracking -->
+<a id='snippet-test-change-tracking'></a>
+```cs
+/// <summary>
+/// Test change tracking with real Neatoo entities.
+/// </summary>
+[Fact]
+public void ChangeTracking_DetectsPropertyChanges()
+{
+    var factory = GetRequiredService<ISkillEntityEmployeeFactory>();
 
+    // Fetch creates an existing (non-new) entity
+    var employee = factory.Fetch(1, "Alice", "Engineering", 50000);
+
+    // After fetch, entity is clean
+    Assert.False(employee.IsNew);
+    Assert.False(employee.IsModified);
+    Assert.False(employee.IsSelfModified);
+
+    // Change a property
+    employee.Name = "Alice Smith";
+
+    // Now entity tracks the change
+    Assert.True(employee.IsModified);
+    Assert.True(employee.IsSelfModified);
+    Assert.True(employee.ModifiedProperties.Contains("Name"));
+
+    // Other properties not tracked
+    Assert.False(employee.ModifiedProperties.Contains("Department"));
+
+    // Change another property
+    employee.Salary = 55000;
+    Assert.True(employee.ModifiedProperties.Contains("Salary"));
+}
+
+/// <summary>
+/// Test IsNew state after Create and Fetch.
+/// </summary>
+[Fact]
+public void ChangeTracking_IsNewState()
+{
+    var factory = GetRequiredService<ISkillEntityEmployeeFactory>();
+
+    // Create produces new entity
+    var newEmployee = factory.Create();
+    Assert.True(newEmployee.IsNew);
+
+    // Fetch produces existing entity
+    var existingEmployee = factory.Fetch(1, "Bob", "Sales", 60000);
+    Assert.False(existingEmployee.IsNew);
+}
 ```
-Tests/
-├── Validation/
-│   ├── EmployeeValidationTests.cs
-│   └── OrderValidationTests.cs
-├── ChangeTracking/
-│   ├── EmployeeChangeTrackingTests.cs
-│   └── OrderChangeTrackingTests.cs
-├── Factory/
-│   ├── EmployeeFactoryTests.cs
-│   └── OrderFactoryTests.cs
-└── Integration/
-    └── OrderWorkflowTests.cs
-```
+<sup><a href='/src/samples/TestingPatternsTests.cs#L146-L195' title='Snippet source file'>snippet source</a> | <a href='#snippet-test-change-tracking' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ## Related
 
 - [Validation](validation.md) - Validation rules
 - [Entities](entities.md) - Entity lifecycle
-- [Factory](factory.md) - Factory methods
+- [Pitfalls](pitfalls.md) - Common mistakes

--- a/src/samples/SamplesTestBase.cs
+++ b/src/samples/SamplesTestBase.cs
@@ -80,6 +80,8 @@ public abstract class SamplesTestBase : IDisposable
 
         // Entities samples
         services.AddScoped<IEntitiesCustomerRepository, MockEntitiesCustomerRepository>();
+        services.AddScoped<IEntitiesCascadeOrderRepository, MockEntitiesCascadeOrderRepository>();
+        services.AddScoped<IEntitiesCascadeItemRepository, MockEntitiesCascadeItemRepository>();
 
         // Async samples
         services.AddScoped<IEmailValidationService, MockEmailValidationService>();


### PR DESCRIPTION
## Summary

- **SKILL.md**: Reorganized by importance/frequency — Key Properties table moved near top (with explicit "no IsDirty" callout), duplicate sections removed, specialized content shortened to pointers
- **Reference files**: Removed duplication across files, cut fabricated source-generation APIs, pruned Blazor from 15 to 5 snippets, Testing from 10 to 4, Pitfalls from 219 to 30 lines
- **New samples**: Added aggregate save cascading entities and tests with MarkdownSnippets integration

Net result: -720 lines across skill/reference files while preserving all essential content via progressive disclosure to `references/` files.

## Test plan

- [x] `dotnet build src/samples/` passes
- [x] `dotnet test src/samples/` — 245 tests pass
- [x] `dotnet mdsnippets` — 260 snippets, 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)