### PR TITLE
chore: bump version to 10.12.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>10.11.0</Version>
+		<Version>10.12.0</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Neatoo 10.11.0** (2026-01-18)
+**Neatoo 10.12.0** (2026-02-26)
 
 ---
 
@@ -12,6 +12,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date | Type | Summary |
 |---------|------|------|---------|
+| [10.12.0](v10.12.0.md) | 2026-02-26 | Bug Fix | Dictionary properties survive JSON bridge round-trip |
 | [10.11.0](v10.11.0.md) | 2026-01-18 | Feature | LazyLoad&lt;T&gt; wrapper type for explicit async lazy loading |
 | [10.10.0](v10.10.0.md) | 2026-01-16 | Feature | Source-generated property backing fields, lazy loading |
 | [10.7.1](v10.7.1.md) | 2026-01-11 | Patch | List IsValid/IsBusy/IsModified caching optimization |
@@ -32,6 +33,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date |
 |---------|------|
+| [10.12.0](v10.12.0.md) | 2026-02-26 |
 | [10.11.0](v10.11.0.md) | 2026-01-18 |
 | [10.10.0](v10.10.0.md) | 2026-01-16 |
 | [10.7.1](v10.7.1.md) | 2026-01-11 |

--- a/docs/release-notes/v10.12.0.md
+++ b/docs/release-notes/v10.12.0.md
@@ -1,0 +1,43 @@
+# Neatoo 10.12.0
+
+**Release Date:** 2026-02-26
+**Type:** Bug Fix
+**Breaking Changes:** No
+
+---
+
+## Summary
+
+Fixes `partial Dictionary<string, string>?` properties losing their values during client-server JSON bridge round-trip serialization. Also updates RemoteFactory dependency to 10.14.0.
+
+---
+
+## Bug Fixes
+
+### Dictionary Properties Survive JSON Round-Trip
+
+`Dictionary<K,V>` partial properties on Neatoo objects (e.g., `CrmTask.Data`, `Activity.Data`) were arriving as `null` on the client after serialization through the RemoteFactory JSON bridge.
+
+**Root cause:** System.Text.Json throws `NotSupportedException: Reference metadata is not supported when deserializing constructor parameters` because `ValidateProperty<T>` uses `[JsonConstructor]` and Dictionary values receive `$id`/`$ref` metadata from `ReferenceHandler.Preserve`.
+
+**Fix (two parts):**
+
+1. **NeatooBaseJsonTypeConverter** - Added manual `DeserializeValidateProperty` method that reads JSON fields individually, deserializing the `Value` field as a standalone call rather than routing through constructor parameters. This bypasses the STJ limitation while preserving `$id`/`$ref` reference resolution.
+
+2. **RemoteFactory 10.14.0** - Removed the Dictionary special-case from `NeatooReferenceResolver.GetReference` that produced empty-string `$id` values, which caused duplicate key errors when multiple dictionaries existed in the same serialization context.
+
+---
+
+## Dependency Updates
+
+| Package | Old Version | New Version |
+|---------|-------------|-------------|
+| Neatoo.RemoteFactory | 10.11.2 | 10.14.0 |
+| Neatoo.RemoteFactory.AspNetCore | 10.11.2 | 10.14.0 |
+
+---
+
+## Related
+
+- [Dictionary Serialization Fix Plan](../plans/completed/dictionary-serialization-fix.md)
+- [Dictionary Serialization Todo](../todos/completed/dictionary-partial-property-serialization.md)


### PR DESCRIPTION
## Summary
- Bumps version from 10.11.0 to 10.12.0
- Adds release notes for the Dictionary serialization bug fix

## Next steps
After merge, tag main: `git tag v10.12.0 && git push origin v10.12.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)