### PR TITLE
Re-version Neatoo from 10.x to 0.x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>10.12.0</Version>
+		<Version>0.12.0</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Neatoo 10.12.0** (2026-02-26)
+**Neatoo 0.12.0** (2026-02-26)
 
 ---
 
@@ -12,20 +12,20 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date | Type | Summary |
 |---------|------|------|---------|
-| [10.12.0](v10.12.0.md) | 2026-02-26 | Bug Fix | Dictionary properties survive JSON bridge round-trip |
-| [10.11.0](v10.11.0.md) | 2026-01-18 | Feature | LazyLoad&lt;T&gt; wrapper type for explicit async lazy loading |
-| [10.10.0](v10.10.0.md) | 2026-01-16 | Feature | Source-generated property backing fields, lazy loading |
-| [10.7.1](v10.7.1.md) | 2026-01-11 | Patch | List IsValid/IsBusy/IsModified caching optimization |
-| [10.7.0](v10.7.0.md) | 2026-01-11 | Feature | Stable rule identification via source generation |
-| [10.6.3](v10.6.3.md) | 2026-01-10 | Patch | Generator unit test infrastructure |
-| [10.6.2](v10.6.2.md) | 2026-01-10 | Patch | Parameterless constructor for EntityBaseServices<T> (unit testing) |
-| [10.6.1](v10.6.1.md) | 2026-01-09 | Patch | KnockOff 10.12.0 upgrade, Moq removed from test projects |
-| [10.6.0](v10.6.0.md) | 2026-01-05 | Feature | RemoteFactory upgrade to 10.5.0 with CancellationToken support |
-| [10.5.0](v10.5.0.md) | 2026-01-04 | Feature | CancellationToken support for async operations |
-| [10.4.0](v10.4.0.md) | 2026-01-04 | Feature | Collapse Base layer - simplified inheritance hierarchy |
-| [10.3.0](v10.3.0.md) | 2026-01-03 | Feature | Root property, ContainingList, Delete/Remove consistency |
-| [10.2.0](v10.2.0.md) | 2026-01-02 | Feature | Stubbable public interfaces |
-| [10.1.1](v10.1.1.md) | 2026-01-01 | Feature | Record support for Value Objects |
+| [0.12.0](v0.12.0.md) | 2026-02-26 | Bug Fix | Dictionary properties survive JSON bridge round-trip |
+| [0.11.0](v0.11.0.md) | 2026-01-18 | Feature | LazyLoad&lt;T&gt; wrapper type for explicit async lazy loading |
+| [0.10.0](v0.10.0.md) | 2026-01-16 | Feature | Source-generated property backing fields, lazy loading |
+| [0.7.1](v0.7.1.md) | 2026-01-11 | Patch | List IsValid/IsBusy/IsModified caching optimization |
+| [0.7.0](v0.7.0.md) | 2026-01-11 | Feature | Stable rule identification via source generation |
+| [0.6.3](v0.6.3.md) | 2026-01-10 | Patch | Generator unit test infrastructure |
+| [0.6.2](v0.6.2.md) | 2026-01-10 | Patch | Parameterless constructor for EntityBaseServices<T> (unit testing) |
+| [0.6.1](v0.6.1.md) | 2026-01-09 | Patch | KnockOff 10.12.0 upgrade, Moq removed from test projects |
+| [0.6.0](v0.6.0.md) | 2026-01-05 | Feature | RemoteFactory upgrade to 10.5.0 with CancellationToken support |
+| [0.5.0](v0.5.0.md) | 2026-01-04 | Feature | CancellationToken support for async operations |
+| [0.4.0](v0.4.0.md) | 2026-01-04 | Feature | Collapse Base layer - simplified inheritance hierarchy |
+| [0.3.0](v0.3.0.md) | 2026-01-03 | Feature | Root property, ContainingList, Delete/Remove consistency |
+| [0.2.0](v0.2.0.md) | 2026-01-02 | Feature | Stubbable public interfaces |
+| [0.1.1](v0.1.1.md) | 2026-01-01 | Feature | Record support for Value Objects |
 
 ---
 
@@ -33,20 +33,20 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date |
 |---------|------|
-| [10.12.0](v10.12.0.md) | 2026-02-26 |
-| [10.11.0](v10.11.0.md) | 2026-01-18 |
-| [10.10.0](v10.10.0.md) | 2026-01-16 |
-| [10.7.1](v10.7.1.md) | 2026-01-11 |
-| [10.7.0](v10.7.0.md) | 2026-01-11 |
-| [10.6.3](v10.6.3.md) | 2026-01-10 |
-| [10.6.2](v10.6.2.md) | 2026-01-10 |
-| [10.6.1](v10.6.1.md) | 2026-01-09 |
-| [10.6.0](v10.6.0.md) | 2026-01-05 |
-| [10.5.0](v10.5.0.md) | 2026-01-04 |
-| [10.4.0](v10.4.0.md) | 2026-01-04 |
-| [10.3.0](v10.3.0.md) | 2026-01-03 |
-| [10.2.0](v10.2.0.md) | 2026-01-02 |
-| [10.1.1](v10.1.1.md) | 2026-01-01 |
+| [0.12.0](v0.12.0.md) | 2026-02-26 |
+| [0.11.0](v0.11.0.md) | 2026-01-18 |
+| [0.10.0](v0.10.0.md) | 2026-01-16 |
+| [0.7.1](v0.7.1.md) | 2026-01-11 |
+| [0.7.0](v0.7.0.md) | 2026-01-11 |
+| [0.6.3](v0.6.3.md) | 2026-01-10 |
+| [0.6.2](v0.6.2.md) | 2026-01-10 |
+| [0.6.1](v0.6.1.md) | 2026-01-09 |
+| [0.6.0](v0.6.0.md) | 2026-01-05 |
+| [0.5.0](v0.5.0.md) | 2026-01-04 |
+| [0.4.0](v0.4.0.md) | 2026-01-04 |
+| [0.3.0](v0.3.0.md) | 2026-01-03 |
+| [0.2.0](v0.2.0.md) | 2026-01-02 |
+| [0.1.1](v0.1.1.md) | 2026-01-01 |
 
 ---
 
@@ -54,9 +54,9 @@ New features, breaking changes, and significant bug fixes.
 
 | Change Type | Version Bump |
 |-------------|--------------|
-| Breaking changes | Major (10.x → 11.0) |
-| New features | Minor (10.1 → 10.2) |
-| Bug fixes | Patch (10.1.0 → 10.1.1) |
+| Breaking changes | Major (0.x → 1.0) |
+| New features | Minor (0.1 → 0.2) |
+| Bug fixes | Patch (0.1.0 → 0.1.1) |
 
 ---
 

--- a/docs/release-notes/v0.1.1.md
+++ b/docs/release-notes/v0.1.1.md
@@ -1,4 +1,4 @@
-# Neatoo 10.1.1
+# Neatoo 0.1.1
 
 **Release Date:** 2026-01-01
 **Type:** Feature Release

--- a/docs/release-notes/v0.10.0.md
+++ b/docs/release-notes/v0.10.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.10.0
+# Neatoo 0.10.0
 
 **Release Date:** 2026-01-16
 **Type:** Feature Release

--- a/docs/release-notes/v0.11.0.md
+++ b/docs/release-notes/v0.11.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.11.0
+# Neatoo 0.11.0
 
 **Release Date:** 2026-01-18
 **Type:** Feature Release
@@ -168,9 +168,9 @@ var isBusy = order.Customer.IsBusy;        // true if loading or wrapped value b
 
 No breaking changes. `LazyLoad<T>` is a new opt-in feature.
 
-If using the old `ValidateProperty<T>.OnLoad` pattern (removed in 10.10.0), migrate to `LazyLoad<T>`:
+If using the old `ValidateProperty<T>.OnLoad` pattern (removed in 0.10.0), migrate to `LazyLoad<T>`:
 
-**Before (10.9.x):**
+**Before (0.9.x):**
 ```csharp
 public partial string Name { get; set; }
 
@@ -180,7 +180,7 @@ public Person()
 }
 ```
 
-**After (10.11.0):**
+**After (0.11.0):**
 ```csharp
 public LazyLoad<string> Name { get; private set; }
 

--- a/docs/release-notes/v0.12.0.md
+++ b/docs/release-notes/v0.12.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.12.0
+# Neatoo 0.12.0
 
 **Release Date:** 2026-02-26
 **Type:** Bug Fix

--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.2.0
+# Neatoo 0.2.0
 
 **Release Date:** 2026-01-02
 **Type:** Feature Release

--- a/docs/release-notes/v0.3.0.md
+++ b/docs/release-notes/v0.3.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.3.0
+# Neatoo 0.3.0
 
 **Release Date:** 2026-01-03
 **Type:** Feature Release

--- a/docs/release-notes/v0.4.0.md
+++ b/docs/release-notes/v0.4.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.4.0
+# Neatoo 0.4.0
 
 **Release Date:** 2026-01-04
 **Type:** Feature Release (Internal Refactoring)
@@ -20,7 +20,7 @@ This release collapses the "Base" layer from all Neatoo inheritance chains, maki
 
 The inheritance chain has been flattened by merging the Base layer into the Validate layer:
 
-**Before (10.3.x):**
+**Before (0.3.x):**
 ```
 Base<T>                    - Property management, INotifyPropertyChanged
   ValidateBase<T>          - Validation, rules engine
@@ -31,7 +31,7 @@ ListBase<I>                - Observable collection
     EntityListBase<I>      - DeletedList, persistence
 ```
 
-**After (10.4.0):**
+**After (0.4.0):**
 ```
 ValidateBase<T>            - Property management, INotifyPropertyChanged, validation, rules engine
     EntityBase<T>          - Persistence awareness, modification tracking

--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.5.0
+# Neatoo 0.5.0
 
 **Release Date:** 2026-01-04
 **Type:** Feature Release

--- a/docs/release-notes/v0.6.0.md
+++ b/docs/release-notes/v0.6.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.6.0
+# Neatoo 0.6.0
 
 **Release Date:** 2026-01-05
 **Type:** Feature Release (Dependency Upgrade)
@@ -139,4 +139,4 @@ All tests pass with the upgraded dependencies.
 
 - [RemoteFactory Guide](../remote-factory.md) - Client-server communication patterns
 - [Aggregates and Entities Guide](../aggregates-and-entities.md) - Factory method usage
-- [v10.5.0 Release Notes](v10.5.0.md) - CancellationToken support in Neatoo core
+- [v0.5.0 Release Notes](v0.5.0.md) - CancellationToken support in Neatoo core

--- a/docs/release-notes/v0.6.1.md
+++ b/docs/release-notes/v0.6.1.md
@@ -1,4 +1,4 @@
-# Neatoo 10.6.1
+# Neatoo 0.6.1
 
 **Release Date:** 2026-01-09
 **Type:** Patch Release (Dependency Update)

--- a/docs/release-notes/v0.6.2.md
+++ b/docs/release-notes/v0.6.2.md
@@ -1,4 +1,4 @@
-# Neatoo 10.6.2
+# Neatoo 0.6.2
 
 **Release Date:** 2026-01-10
 **Type:** Patch Release (Unit Testing Support)

--- a/docs/release-notes/v0.6.3.md
+++ b/docs/release-notes/v0.6.3.md
@@ -1,4 +1,4 @@
-# Neatoo 10.6.3
+# Neatoo 0.6.3
 
 **Release Date:** 2026-01-10
 **Type:** Patch Release (Code Quality)

--- a/docs/release-notes/v0.7.0.md
+++ b/docs/release-notes/v0.7.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.7.0
+# Neatoo 0.7.0
 
 **Release Date:** 2026-01-11
 **Type:** Feature Release

--- a/docs/release-notes/v0.7.1.md
+++ b/docs/release-notes/v0.7.1.md
@@ -1,4 +1,4 @@
-# Neatoo 10.7.1
+# Neatoo 0.7.1
 
 **Release Date:** 2026-01-11
 **Type:** Patch Release (Performance)

--- a/docs/release-notes/v0.8.0.md
+++ b/docs/release-notes/v0.8.0.md
@@ -1,4 +1,4 @@
-# Neatoo 10.8.0
+# Neatoo 0.8.0
 
 **Release Date:** 2026-01-11
 **Type:** Minor Release (New API)
@@ -24,7 +24,7 @@ public interface IEntityBase : IValidateBase
     // Existing
     Task<IEntityBase> Save();
 
-    // New in 10.8.0
+    // New in 0.8.0
     Task<IEntityBase> Save(CancellationToken token);
 }
 ```

--- a/docs/release-notes/v0.9.3.md
+++ b/docs/release-notes/v0.9.3.md
@@ -1,4 +1,4 @@
-# Neatoo 10.9.3
+# Neatoo 0.9.3
 
 **Release Date:** 2026-01-13
 **Type:** Patch Release (Dependency Update)

--- a/docs/todos/cancellation-token-samples.md
+++ b/docs/todos/cancellation-token-samples.md
@@ -86,6 +86,6 @@ public async Task Insert([Service] IDbContext db, CancellationToken cancellation
 
 ## References
 
-- Release note: `docs/release-notes/v10.8.0.md`
+- Release note: `docs/release-notes/v0.8.0.md`
 - RemoteFactory CancellationToken support: `RemoteFactory/docs/todos/completed/cancellation-token-support.md`
 - Neatoo CancellationToken support: `Neatoo/docs/todos/completed/cancellation-token-support.md`


### PR DESCRIPTION
## Summary
- Re-version Neatoo from 10.x to 0.x to reflect pre-release status
- Rename all 16 release note files from `v10.x.y.md` to `v0.x.y.md`
- Update `Directory.Build.props` version from 10.12.0 to 0.12.0
- Update all Neatoo version references in release notes and docs
- RemoteFactory/KnockOff dependency versions unchanged

Also completed outside this PR:
- Deleted 19 `v10.x` git tags (local and remote)
- Unlisted all 47 Neatoo and Neatoo.Blazor.MudNeatoo versions from NuGet (9.x and 10.x)

## Test plan
- [ ] Verify `dotnet build` succeeds with new version
- [ ] Verify release note links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)