### PR TITLE
Fix rules lifecycle docs — rules don't fire during factory methods

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -431,13 +431,15 @@ public void PauseAllActions_BatchUpdatesWithoutValidation()
     }
 
     // After resume (automatic when using block ends):
-    // - Validation rules execute for changed properties
-    // - PropertyChanged events fire
+    // - IsPaused is false — future property changes will trigger rules
+    // - Rules do NOT run for changes made while paused
+    // - PropertyChanged does NOT fire for changes made while paused
+    // - To run rules after batch updates: await order.RunRules(RunRulesFlag.All);
     Assert.False(order.IsPaused);
     Assert.Equal("PROD-001", order.ProductCode);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L718-L743' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-pause-actions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L718-L745' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-pause-actions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 PauseAllActions behavior:
@@ -477,7 +479,7 @@ public void LoadValue_DataLoadingWithoutValidation()
     // (In real usage, factory method would call RunRules after loading)
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L745-L763' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-load-value' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L747-L765' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-load-value' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ChangeReason integration:
@@ -526,7 +528,7 @@ public void ValidationCascade_ChildToParent()
     Assert.True(invoice.IsValid);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L765-L794' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-cascade' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L767-L796' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-cascade' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Cascade characteristics:
@@ -575,7 +577,7 @@ public async Task MetaProperties_TrackValidationState()
     Assert.NotEmpty(account.PropertyMessages);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L796-L824' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-meta-properties' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L798-L826' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-meta-properties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Meta-property definitions:
@@ -622,7 +624,7 @@ public async Task ValidateBeforeSave_IsSavableCheck()
     Assert.True(order.IsSavable);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L826-L852' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-before-save' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L828-L854' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-before-save' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Save validation patterns:
@@ -668,7 +670,7 @@ public async Task CancellationToken_CancelAsyncValidation()
     // Assert.Equal("Validation cancelled", order.ObjectInvalid);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L854-L879' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-cancellation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L856-L881' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-cancellation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Cancellation behavior:
@@ -737,7 +739,7 @@ public async Task WorkWithValidationMessages_FilterAndAccess()
     Assert.Equal(2, product.PropertyMessages.Count);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L881-L912' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-messages-collection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L883-L914' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-messages-collection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Message collection operations:

--- a/skills/neatoo/SKILL.md
+++ b/skills/neatoo/SKILL.md
@@ -158,9 +158,28 @@ public SkillValidationExample(IEntityBaseServices<SkillValidationExample> servic
 <sup><a href='/src/samples/SkillValidationSamples.cs#L52-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-skill-validation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-RuleManager also provides `AddAction`, `AddActionAsync`, `AddValidationAsync`, and class-based rules. **`AddValidation`/`AddValidationAsync` accept exactly one trigger property** — for multiple triggers, use a class-based rule. Rules do **not** fire during `[Create]`/`[Fetch]` or `LoadValue`. See `references/validation.md` for details.
+RuleManager also provides `AddAction`, `AddActionAsync`, `AddValidationAsync`, and class-based rules. **`AddValidation`/`AddValidationAsync` accept exactly one trigger property** — for multiple triggers, use a class-based rule. See `references/validation.md` for details.
 
 Check validation state with `IsValid`, `IsSelfValid`, and `PropertyMessages`.
+
+### Rules Do NOT Fire During Factory Methods
+
+**Rules (including AddAction computed properties) do NOT fire during `[Create]`, `[Fetch]`, `[Insert]`, `[Update]`, `[Delete]`, or `LoadValue`.** Factory operations are wrapped in `PauseAllActions()`. `ResumeAllActions()` does NOT run rules — it only recalculates cached validity. `PropertyChanged` does NOT fire for changes made while paused.
+
+**`RunRules` works while paused** — it has no `IsPaused` guard. Call `await RunRules(RunRulesFlag.All)` at the end of any factory method that sets properties with dependent AddAction rules:
+
+```csharp
+[Create]
+public async Task Create()
+{
+    Quantity = 10;
+    UnitPrice = 5.00m;
+    await RunRules(RunRulesFlag.All);  // Forces computed properties to populate
+    // Total is now 50.00
+}
+```
+
+Without this call, computed properties remain at their default values when the entity reaches the client. See `references/rules-lifecycle.md` for the complete execution lifecycle, `RunRulesFlag` enum reference, and the factory method timeline.
 
 ### Child Property Triggers — Parent Reacts to Child Changes
 
@@ -203,6 +222,7 @@ Detailed documentation for each topic area:
 - **`references/base-classes.md`** - Neatoo-to-DDD mapping, when to use each base
 - **`references/properties.md`** - Partial properties, change tracking, calculated properties
 - **`references/validation.md`** - RuleManager, attributes, async validation
+- **`references/rules-lifecycle.md`** - When rules fire and when they don't, RunRulesFlag enum, factory method gap, RunRules works while paused
 - **`references/shared-rules.md`** - Shared rules across entities via interface-typed AsyncRuleBase and DI injection
 - **`references/entities.md`** - EntityBase lifecycle, persistence, Save routing
 - **`references/collections.md`** - EntityListBase, parent-child relationships, deletion tracking

--- a/skills/neatoo/references/pitfalls.md
+++ b/skills/neatoo/references/pitfalls.md
@@ -21,7 +21,7 @@ This document captures important patterns and behaviors when working with Neatoo
 | Forgetting to iterate DeletedList in parent's `[Update]` | Removed children are never deleted from the database | After saving active children, iterate `ChildList.DeletedList` and call `childFactory.SaveAsync(deleted)` for each |
 | Forgetting items are modified when added to collections | Adding a fetched (non-new) item marks both item and list as `IsModified` | Expected behavior—adding to a new parent is a state change |
 | Kitchen-sink rule with early return | Only one form input shows an error at a time — user plays whack-a-mole | Use `new RuleMessages().If(...).If(...)` to return all errors, or use separate per-property rules |
-| Worrying about rules firing during Fetch/Create | **Not a real risk.** `LoadValue` uses `ChangeReason.Load` (rules skip it). Factory operations (`[Create]`, `[Fetch]`) are wrapped in `PauseAllActions()` by the framework. Rules do not fire during hydration — no defensive coding needed. | No action required — this is handled by the framework |
+| Expecting AddAction computed properties to populate during `[Create]`/`[Fetch]` | **Rules do NOT fire during factory methods.** Factory operations are wrapped in `PauseAllActions()`. `ResumeAllActions()` does NOT run rules — it only recalculates cached validity. `PropertyChanged` does NOT fire for changes made while paused. Computed properties (AddAction) remain at their default values. | Call `await RunRules(RunRulesFlag.All)` at the end of the factory method. `RunRules` has no `IsPaused` guard — it works even while paused. See [rules-lifecycle.md](rules-lifecycle.md) |
 
 ---
 

--- a/skills/neatoo/references/rules-lifecycle.md
+++ b/skills/neatoo/references/rules-lifecycle.md
@@ -1,0 +1,177 @@
+# Rules Execution Lifecycle
+
+Rules in Neatoo follow strict execution rules. Understanding when rules fire — and critically, when they do NOT — prevents silent data bugs where computed properties return stale defaults.
+
+## When Rules Fire
+
+| Trigger | Rules Execute? | Details |
+|---------|---------------|---------|
+| Property setter (not paused) | Yes | `ChildNeatooPropertyChanged` calls `RunRules(propertyName)` |
+| Explicit `await RunRules()` | Yes | **Always works — even while paused** |
+| Explicit `await RunRules(RunRulesFlag.All)` | Yes | Runs ALL rules regardless of trigger properties |
+
+## When Rules Do NOT Fire
+
+| Situation | Why | What To Do |
+|-----------|-----|------------|
+| During `[Create]`, `[Fetch]`, `[Insert]`, `[Update]`, `[Delete]` | `FactoryStart()` calls `PauseAllActions()` before your code runs | Call `await RunRules(RunRulesFlag.All)` at end of factory method |
+| During `PauseAllActions()` block | `IsPaused = true` — `ChildNeatooPropertyChanged` skips rules | Call `await RunRules(RunRulesFlag.All)` inside or after the block |
+| `LoadValue` / `this["Prop"].LoadValue(x)` | Uses `ChangeReason.Load` — framework skips rules for Load events | Call `await RunRules(RunRulesFlag.All)` after loading |
+| During JSON deserialization | `OnDeserializing` calls `PauseAllActions()` | Automatic — `OnDeserialized` calls `ResumeAllActions()` |
+
+## ResumeAllActions Does NOT Run Rules
+
+This is the most common source of confusion. `ResumeAllActions()` (called by `FactoryComplete` and `PauseAllActions` dispose) does the following:
+
+- Sets `IsPaused = false`
+- Recalculates cached `IsValid` and `IsSelfValid`
+- Fires `PropertyChanged` for `IsValid`/`IsSelfValid` **only if they changed**
+- Recalculates `IsBusy`
+
+It does **NOT**:
+
+- Run any rules
+- Fire `PropertyChanged` for properties changed while paused
+- Queue or replay skipped rule triggers
+- Run AddAction computed property rules
+
+## RunRules Works While Paused
+
+`RunRules()` has **no IsPaused guard** — neither in `ValidateBase` nor in `RuleManager`. Call it inside a factory method or a `PauseAllActions()` block and it executes all matching rules immediately.
+
+```csharp
+[Create]
+public async Task Create()
+{
+    Quantity = 10;
+    UnitPrice = 5.00m;
+    // Rules are paused (FactoryStart called PauseAllActions)
+    // but RunRules works anyway:
+    await RunRules(RunRulesFlag.All);
+    // Total is now calculated
+}
+
+[Fetch]
+internal async Task Fetch(int id, [Service] IRepository repo)
+{
+    var data = repo.GetOrder(id);
+    this["Quantity"].LoadValue(data.Quantity);
+    this["UnitPrice"].LoadValue(data.UnitPrice);
+    // LoadValue uses ChangeReason.Load — rules skipped
+    // Force rules to compute derived values:
+    await RunRules(RunRulesFlag.All);
+}
+```
+
+**Chaining caveat:** When a rule sets a property while paused, the property value IS updated, but the property change does not cascade to trigger other rules. `RunRulesFlag.All` handles this because it runs ALL rules regardless of triggers — not just rules whose trigger property changed.
+
+## The Computed Property Gap
+
+This is the most common bug. AddAction rules compute derived values, but they never fire during factory methods:
+
+```csharp
+public Order(IEntityBaseServices<Order> services) : base(services)
+{
+    // This rule computes Total when Quantity or UnitPrice changes
+    RuleManager.AddAction(
+        t => t.Total = t.Quantity * t.UnitPrice,
+        t => t.Quantity, t => t.UnitPrice);
+}
+
+// WRONG: Total is 0 after Create returns — rule never fired
+[Create]
+public void Create()
+{
+    Quantity = 10;
+    UnitPrice = 5.00m;
+    // Total is still 0!
+}
+
+// RIGHT: Call RunRules to force computed values
+[Create]
+public async Task Create()
+{
+    Quantity = 10;
+    UnitPrice = 5.00m;
+    await RunRules(RunRulesFlag.All);
+    // Total is now 50.00
+}
+```
+
+**This applies to all factory methods** — `[Create]`, `[Fetch]`, `[Insert]`, `[Update]`, `[Delete]`. Any factory method that sets properties which have dependent AddAction rules must call `await RunRules(RunRulesFlag.All)` at the end.
+
+## Factory Method Lifecycle
+
+```
+1. Generated factory code calls FactoryStart(FactoryOperation)
+   → PauseAllActions() → IsPaused = true
+   → All property change events, rules, modification tracking suspended
+
+2. Your factory method runs ([Create], [Fetch], etc.)
+   → Property setters work — values ARE set
+   → But ChildNeatooPropertyChanged skips because IsPaused
+   → No rules fire, no PropertyChanged fires, no modification tracking
+   → Call await RunRules(RunRulesFlag.All) here if needed
+
+3. Generated factory code calls FactoryComplete(FactoryOperation)
+   → ResumeAllActions() → IsPaused = false
+   → Validity recalculated, meta state reset
+   → NO rules run, NO PropertyChanged for changed properties
+   → For EntityBase: MarkNew/MarkOld/MarkUnmodified based on operation
+
+4. Factory returns to caller
+   → Object is now unpaused
+   → Next property change triggers rules normally
+```
+
+## RunRulesFlag Enum Reference
+
+```csharp
+[Flags]
+public enum RunRulesFlag
+{
+    None = 0,          // Run no rules
+    NoMessages = 1,    // Run rules with no validation messages
+    Messages = 2,      // Run rules with messages (known issue: never matches*)
+    NotExecuted = 4,   // Run rules that haven't been executed yet
+    Executed = 8,      // Run rules that have already been executed
+    Self = 16,         // Run only this object's rules (skip child properties)
+    All = NoMessages | Messages | NotExecuted | Executed | Self
+}
+```
+
+**Common usage:**
+
+| Call | When |
+|------|------|
+| `await RunRules(RunRulesFlag.All)` | Re-run all rules (default). Clears messages first. Use at end of factory methods. |
+| `await RunRules(RunRulesFlag.NotExecuted)` | Run only rules that haven't executed yet. Does not clear existing messages. |
+| `await RunRules(RunRulesFlag.Self)` | Run this object's rules only, skip child property rules. |
+| `await RunRules("PropertyName")` | Run rules triggered by a specific property. |
+
+*`Messages` flag checks `IRule.Messages` which is never populated. `NoMessages` always matches (empty list), `Messages` never matches. Use `All` or `NotExecuted` instead.
+
+## PauseAllActions Usage
+
+`PauseAllActions()` returns `IDisposable`. Use for batch updates where intermediate rule execution is unnecessary:
+
+```csharp
+// Batch update — no rules fire between assignments
+using (entity.PauseAllActions())
+{
+    entity.FirstName = "John";
+    entity.LastName = "Doe";
+    entity.Email = "john@example.com";
+    // Optional: force rules if computed values needed before resume
+    await entity.RunRules(RunRulesFlag.All);
+}
+// IsPaused is now false
+// Future property changes trigger rules normally
+// BUT: no rules ran for the batch changes unless RunRules was called above
+```
+
+## Related
+
+- [validation.md](validation.md) — Rule types (AddAction, AddValidation, AddActionAsync, class-based rules)
+- [pitfalls.md](pitfalls.md) — Common mistakes including the computed property gap
+- [domain-logic-placement.md](domain-logic-placement.md) — Where to use AddAction vs AddValidation

--- a/skills/neatoo/references/validation.md
+++ b/skills/neatoo/references/validation.md
@@ -380,13 +380,15 @@ public void PauseAllActions_BatchUpdatesWithoutValidation()
     }
 
     // After resume (automatic when using block ends):
-    // - Validation rules execute for changed properties
-    // - PropertyChanged events fire
+    // - IsPaused is false — future property changes will trigger rules
+    // - Rules do NOT run for changes made while paused
+    // - PropertyChanged does NOT fire for changes made while paused
+    // - To run rules after batch updates: await order.RunRules(RunRulesFlag.All);
     Assert.False(order.IsPaused);
     Assert.Equal("PROD-001", order.ProductCode);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L718-L743' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-pause-actions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L718-L745' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-pause-actions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Cascading Validation
@@ -425,7 +427,7 @@ public void ValidationCascade_ChildToParent()
     Assert.True(invoice.IsValid);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L765-L794' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-cascade' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L767-L796' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-cascade' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Meta Properties for Validation
@@ -463,7 +465,7 @@ public async Task MetaProperties_TrackValidationState()
     Assert.NotEmpty(account.PropertyMessages);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L796-L824' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-meta-properties' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L798-L826' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-meta-properties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Validation Before Save
@@ -499,7 +501,7 @@ public async Task ValidateBeforeSave_IsSavableCheck()
     Assert.True(order.IsSavable);
 }
 ```
-<sup><a href='/src/samples/ValidationSamples.cs#L826-L852' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-before-save' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ValidationSamples.cs#L828-L854' title='Snippet source file'>snippet source</a> | <a href='#snippet-validation-before-save' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Async Action Rules (AddActionAsync)
@@ -567,9 +569,9 @@ RuleManager.AddActionAsync(
 `AddActionAsync` rules do **not** fire during `LoadValue` or deserialization:
 
 - `LoadValue` fires `NeatooPropertyChanged` with `ChangeReason.Load`. The framework skips rules for `Load` events — only `SetParent` is called.
-- During factory operations (`[Create]`, `[Fetch]`, etc.) and JSON deserialization, `PauseAllActions()` is called. Rules are suppressed until `ResumeAllActions()` runs after the operation completes.
+- During factory operations (`[Create]`, `[Fetch]`, etc.) and JSON deserialization, `PauseAllActions()` is called. Rules are suppressed. `ResumeAllActions()` does NOT run rules — it only recalculates cached validity and resets meta state. `PropertyChanged` does NOT fire for changes made while paused.
 
-This means properties populated via `LoadValue` in a `[Fetch]` method will not trigger `AddActionAsync` rules. To run rules after loading, call `RunRules(RunRulesFlag.All)` explicitly.
+This means properties populated via `LoadValue` in a `[Fetch]` method will not trigger `AddActionAsync` rules. To run rules after loading, call `await RunRules(RunRulesFlag.All)` at the end of the factory method. `RunRules` has no `IsPaused` guard — it works even while paused. See [rules-lifecycle.md](rules-lifecycle.md).
 
 ### Exception Propagation
 

--- a/src/Design/Design.Domain/CommonGotchas.cs
+++ b/src/Design/Design.Domain/CommonGotchas.cs
@@ -31,18 +31,20 @@ namespace Design.Domain;
 //       // Total is still 0! The calculation rule hasn't run.
 //   }
 //
-// RIGHT (Option 1): Calculate explicitly in Create:
+// RIGHT: Call RunRules at the end of your factory method.
+// RunRules works even while paused — it has no IsPaused guard.
 //   [Create]
-//   public void Create() {
+//   public async Task Create() {
 //       Quantity = 10;
 //       Price = 5.00m;
-//       Total = Quantity * Price;  // Set explicitly
+//       await RunRules(RunRulesFlag.All);  // Forces all rules to execute
+//       // Total is now 50.00
 //   }
 //
-// RIGHT (Option 2): Await rules after Create completes:
-//   var entity = factory.Create();
-//   await entity.WaitForTasks();  // Rules run after FactoryComplete
-//   // Now Total is calculated
+// NOTE: ResumeAllActions (called by FactoryComplete) does NOT run rules.
+// It only recalculates cached validity. PropertyChanged does NOT fire
+// for changes made while paused. The only thing that runs rules is
+// an explicit RunRules() call or a property change after unpausing.
 //
 // WHY: Rules are paused during factory operations to prevent partial state
 // from triggering validation failures or infinite loops.
@@ -89,14 +91,16 @@ internal partial class Gotcha1Demo : ValidateBase<Gotcha1Demo>, IGotcha1Demo
     }
 
     /// <summary>
-    /// RIGHT WAY: Calculate explicitly during Create.
+    /// RIGHT WAY: Call RunRules at end of factory method.
+    /// RunRules works even while paused — no IsPaused guard.
     /// </summary>
     [Create]
-    public void CreateWithExplicitCalculation()
+    public async Task CreateWithRunRules()
     {
         Quantity = 10;
         Price = 5.00m;
-        Total = Quantity * Price;  // Calculate explicitly
+        await RunRules(RunRulesFlag.All);  // Forces all rules to execute
+        // Total is now 50.00
     }
 }
 
@@ -332,25 +336,20 @@ public interface IServerOnlyService
 //       entity.Price = 5.00m;
 //   }
 //   // Expecting Total to be 50.00 - BUT rules haven't run yet!
-//   // ResumeAllActions() resumes the ability to fire rules,
-//   // but doesn't automatically run rules for changes made while paused.
+//   // ResumeAllActions() does NOT run rules. It does NOT fire PropertyChanged
+//   // for changes made while paused. It only recalculates cached validity.
 //
-// RIGHT (Option 1): Run rules explicitly after resume:
+// RIGHT: Call RunRules inside or after the paused block.
+// RunRules works even while paused — it has no IsPaused guard.
 //   using (entity.PauseAllActions()) {
 //       entity.Quantity = 10;
 //       entity.Price = 5.00m;
+//       await entity.RunRules(RunRulesFlag.All);  // Works while paused
 //   }
-//   await entity.RunRules(RunRulesFlag.All);  // Explicitly run all rules
-//   // Now Total is 50.00
-//
-// RIGHT (Option 2): Set one property at a time without pausing:
-//   entity.Quantity = 10;
-//   entity.Price = 5.00m;  // Each setter triggers rules
-//   await entity.WaitForTasks();  // Wait for async rules
 //   // Total is 50.00
 //
 // DESIGN DECISION: PauseAllActions is for performance during batch updates.
-// You must explicitly run rules afterward if you need calculations.
+// You must explicitly call RunRules() if you need computed values.
 // =============================================================================
 
 /// <summary>
@@ -490,8 +489,8 @@ public interface IGotcha5Repository
 // +-----+------------------------------------------+-----------------------------+
 // | #   | Gotcha                                   | Solution                    |
 // +-----+------------------------------------------+-----------------------------+
-// | 1   | Rules don't fire during [Create]        | Calculate explicitly or     |
-// |     |                                          | await WaitForTasks()        |
+// | 1   | Rules don't fire during [Create]        | await RunRules() at end     |
+// |     |                                          | of factory method           |
 // +-----+------------------------------------------+-----------------------------+
 // | 2   | DeletedList ignores IsNew=true items    | Expected behavior - new     |
 // |     |                                          | items don't need deletion   |
@@ -499,8 +498,8 @@ public interface IGotcha5Repository
 // | 3   | [Service] on methods needs [Remote]     | Add [Remote] or use         |
 // |     |                                          | constructor injection       |
 // +-----+------------------------------------------+-----------------------------+
-// | 4   | PauseAllActions stops rule calculations | Call RunRules() after       |
-// |     |                                          | ResumeAllActions()          |
+// | 4   | PauseAllActions stops rule calculations | Call RunRules() explicitly  |
+// |     |                                          | (works even while paused)   |
 // +-----+------------------------------------------+-----------------------------+
 // | 5   | IsModified includes children            | Use IsSelfModified for      |
 // |     |                                          | current object only         |

--- a/src/Design/Design.Tests/GotchaTests/CommonGotchaTests.cs
+++ b/src/Design/Design.Tests/GotchaTests/CommonGotchaTests.cs
@@ -50,7 +50,7 @@ public class CommonGotchaTests
     }
 
     [TestMethod]
-    public async Task Gotcha1_RulesFireAfterCreate_WithWaitForTasks()
+    public async Task Gotcha1_RulesFireAfterCreate_WithExplicitRunRules()
     {
         // Arrange
         var factory = _scope.GetRequiredService<IGotcha1DemoFactory>();
@@ -58,8 +58,7 @@ public class CommonGotchaTests
         // Act
         var entity = factory.Create();
 
-        // After Create completes, we can trigger rules by modifying a property
-        // OR by calling RunRules explicitly
+        // RunRules works even after factory (IsPaused is now false)
         await entity.RunRules(RunRulesFlag.All);
 
         // Assert - Now the rule has run
@@ -68,18 +67,19 @@ public class CommonGotchaTests
     }
 
     [TestMethod]
-    public void Gotcha1_ExplicitCalculationInCreate_WorksCorrectly()
+    public async Task Gotcha1_RunRulesInsideFactoryMethod_WorksWhilePaused()
     {
         // Arrange
         var factory = _scope.GetRequiredService<IGotcha1DemoFactory>();
 
-        // Act - Use the Create overload that calculates explicitly
-        var entity = factory.CreateWithExplicitCalculation();
+        // Act - Use the Create overload that calls RunRules inside the factory method
+        var entity = await factory.CreateWithRunRules();
 
-        // Assert - Total is set explicitly in Create, no rule needed
+        // Assert - RunRules executed all rules even while paused during factory
         Assert.AreEqual(10, entity.Quantity);
         Assert.AreEqual(5.00m, entity.Price);
-        Assert.AreEqual(50.00m, entity.Total, "Total should be 50 from explicit calculation");
+        Assert.AreEqual(50.00m, entity.Total, "Total should be 50 from RunRules inside factory");
+        Assert.IsTrue(entity.RuleHasRun, "Rule should have run via RunRules inside factory");
     }
 
     [TestMethod]
@@ -210,6 +210,25 @@ public class CommonGotchaTests
 
         // Assert - Now Total is calculated
         Assert.AreEqual(50.00m, entity.Total, "Total should be calculated after explicit RunRules");
+    }
+
+    [TestMethod]
+    public async Task Gotcha4_RunRulesWhilePaused_WorksCorrectly()
+    {
+        // Arrange
+        var factory = _scope.GetRequiredService<IGotcha4DemoFactory>();
+        var entity = factory.Create();
+
+        // Act - RunRules inside paused block (no IsPaused guard)
+        using (entity.PauseAllActions())
+        {
+            entity.Quantity = 10;
+            entity.Price = 5.00m;
+            await entity.RunRules(RunRulesFlag.All);
+        }
+
+        // Assert - RunRules executed even while paused
+        Assert.AreEqual(50.00m, entity.Total, "Total should be calculated - RunRules works while paused");
     }
 
     [TestMethod]

--- a/src/samples/ValidationSamples.cs
+++ b/src/samples/ValidationSamples.cs
@@ -735,8 +735,10 @@ public class ValidationSamplesTests : SamplesTestBase
         }
 
         // After resume (automatic when using block ends):
-        // - Validation rules execute for changed properties
-        // - PropertyChanged events fire
+        // - IsPaused is false — future property changes will trigger rules
+        // - Rules do NOT run for changes made while paused
+        // - PropertyChanged does NOT fire for changes made while paused
+        // - To run rules after batch updates: await order.RunRules(RunRulesFlag.All);
         Assert.False(order.IsPaused);
         Assert.Equal("PROD-001", order.ProductCode);
     }


### PR DESCRIPTION
## Summary
- Correct wrong comments claiming rules execute and PropertyChanged fires on `ResumeAllActions()` — neither happens
- Replace misleading "explicit calculation" and `WaitForTasks()` options with the single correct pattern: `await RunRules(RunRulesFlag.All)` inside the factory method
- Add new `rules-lifecycle.md` skill reference with complete `RunRulesFlag` enum, factory timeline, and paused behavior documentation
- Add prominent "Rules Do NOT Fire During Factory Methods" section to SKILL.md

## Test plan
- [x] Design.Tests: 99 passed
- [x] Samples: 254 passed
- [x] New test: `Gotcha1_RunRulesInsideFactoryMethod_WorksWhilePaused` proves RunRules works while paused during factory
- [x] New test: `Gotcha4_RunRulesWhilePaused_WorksCorrectly` proves RunRules works inside PauseAllActions block
- [x] `dotnet mdsnippets` ran clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)