### PR TITLE
feat: change Logger from ILogger to ILogger<T>

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>0.27.0</Version>
+		<Version>0.28.0</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/docs/plans/completed/validatebase-logger-ilogger-t.md
+++ b/docs/plans/completed/validatebase-logger-ilogger-t.md
@@ -1,0 +1,165 @@
+# Change ValidateBase<T>.Logger from ILogger to ILogger<T>
+
+**Date:** 2026-04-08
+**Related Todo:** [Investigate Making ValidateBase<T>.Logger an ILogger<T>](../todos/validatebase-logger-ilogger-t.md)
+**Status:** Complete
+**Last Updated:** 2026-04-08
+
+---
+
+## Overview
+
+Change the `Logger` property exposed to consumers from `ILogger` (category `"Neatoo.Trace"`) to `ILogger<T>` (category = the consumer's entity type). This lets consumers use `Logger` for application-level logging with proper type-categorized output, replacing a framework-only trace logger they couldn't meaningfully use.
+
+---
+
+## Business Requirements Context
+
+[Architect fills in Step 3]
+
+**Source:** [Todo Requirements Review](../todos/validatebase-logger-ilogger-t.md#requirements-review)
+
+### Relevant Existing Requirements
+
+[Architect fills in Step 3]
+
+### Gaps
+
+[Architect fills in Step 3]
+
+### Contradictions
+
+[Architect fills in Step 3]
+
+### Recommendations for Architect
+
+[Architect fills in Step 3]
+
+---
+
+## Business Rules (Testable Assertions)
+
+[Architect fills in Step 3]
+
+### Test Scenarios
+
+[Architect fills in Step 3]
+
+---
+
+## Approach
+
+Single `ILogger<T>` replaces the current `ILogger`. No separate framework trace logger needed because:
+
+1. **Only 2 framework log calls** use `Services.Logger` — both in `EntityBase.FactoryComplete` (lines 561, 587). These are `Trace` level with structured EventIds (10400/10401) and already include the type name in the message. Switching the logger category from `"Neatoo.Trace"` to the entity's type doesn't lose filterability — consumers can filter by EventId or LogLevel.
+
+2. **Serialization logging is independent** — `NeatooBaseJsonTypeConverter` and `NeatooListBaseJsonTypeConverter` create their own `"Neatoo.Trace"` loggers via `ILoggerFactory.CreateLogger("Neatoo.Trace")`. These are unaffected.
+
+3. **Source generator doesn't reference Logger** — no generator changes needed.
+
+---
+
+## Domain Model Behavioral Design
+
+N/A — this is a framework infrastructure change, not a domain model change. No computed properties, visibility flags, reactive rules, or validation rules are affected.
+
+---
+
+## Design
+
+### Interface Change
+
+```csharp
+// IValidateBaseServices.cs — change ILogger to ILogger<T>
+public interface IValidateBaseServices<T> where T : ValidateBase<T>
+{
+    ILogger<T> Logger { get; }  // was: ILogger Logger { get; }
+}
+```
+
+### Services Implementation Change
+
+```csharp
+// ValidateBaseServices.cs — change property type and creation
+public ILogger<T> Logger { get; protected set; }
+
+// In constructors without ILoggerFactory:
+this.Logger = (ILogger<T>)NullLoggerFactory.Instance.CreateLogger<T>();
+
+// In constructors with ILoggerFactory:
+this.Logger = loggerFactory?.CreateLogger<T>()
+    ?? (ILogger<T>)NullLoggerFactory.Instance.CreateLogger<T>();
+```
+
+`NullLoggerFactory.Instance.CreateLogger<T>()` returns `ILogger` — the cast to `ILogger<T>` is safe because `NullLogger<T>` implements `ILogger<T>` and the `LoggerFactory.CreateLogger<T>()` extension method returns `ILogger<T>`. We should use `new NullLogger<T>()` as the fallback instead of casting.
+
+```csharp
+// Correct fallback:
+this.Logger = new NullLogger<T>();
+
+// With factory:
+this.Logger = loggerFactory?.CreateLogger<T>() ?? new NullLogger<T>();
+```
+
+### EntityBaseServices Change
+
+Same pattern — inherits `Logger` from `ValidateBaseServices<T>`, just update the constructor assignments:
+
+```csharp
+// EntityBaseServices.cs constructors that set Logger:
+this.Logger = loggerFactory.CreateLogger<T>();
+// and
+this.Logger = loggerFactory?.CreateLogger<T>() ?? new NullLogger<T>();
+```
+
+### Consumer-Facing Change
+
+```csharp
+// ValidateBase.cs — change return type
+protected ILogger<T> Logger => Services.Logger;  // was: ILogger Logger
+```
+
+### EntityBase FactoryComplete — No Change Needed
+
+The `NeatooTraceLog` extension methods are defined on `ILogger`, and `ILogger<T>` implements `ILogger`, so the existing calls compile without modification:
+
+```csharp
+Logger.FactoryCompleteStarted(opName, typeName, ...);  // still works
+Logger.FactoryCompleteFinished(opName, typeName, ...);  // still works
+```
+
+---
+
+## Implementation Steps
+
+1. **Change `IValidateBaseServices<T>.Logger`** from `ILogger` to `ILogger<T>`
+2. **Update `ValidateBaseServices<T>`** — change property type to `ILogger<T>`, update all constructor assignments to use `CreateLogger<T>()` / `new NullLogger<T>()`
+3. **Update `EntityBaseServices<T>`** — update constructor assignments that set `this.Logger`
+4. **Update `ValidateBase<T>.Logger`** — change return type from `ILogger` to `ILogger<T>`
+5. **Build and fix any compilation errors** — the `NeatooTraceLog` extension methods on `ILogger` should still work since `ILogger<T> : ILogger`
+6. **Run all tests**
+
+---
+
+## Acceptance Criteria
+
+- [ ] `ValidateBase<T>.Logger` is `ILogger<T>` where `T` is the consumer's entity type
+- [ ] Framework trace logging in `EntityBase.FactoryComplete` still works (extension methods on `ILogger`)
+- [ ] Serialization logging in JSON converters is unaffected (they use their own logger)
+- [ ] All existing tests pass without modification
+- [ ] No source generator changes needed
+- [ ] Consumers can call `Logger.LogInformation(...)` and see output under their entity type's category
+
+---
+
+## Dependencies
+
+- `Microsoft.Extensions.Logging.Abstractions` — already referenced, provides `NullLogger<T>` and `ILogger<T>`
+
+---
+
+## Risks / Considerations
+
+1. **Breaking change for `IValidateBaseServices<T>` implementors** — Anyone who directly implements this interface (rather than inheriting `ValidateBaseServices<T>`) will need to update their `Logger` property. This is unlikely since the interface is infrastructure, but it is technically a public API change. Bump minor version.
+2. **Log category change** — Framework trace messages in `FactoryComplete` will now appear under the entity's type category instead of `"Neatoo.Trace"`. The EventIds (10400/10401) still uniquely identify them. Anyone filtering by category `"Neatoo.Trace"` for these two messages would need to adjust. Low risk since the trace log feature is new (v0.27.0).
+3. **`NullLogger<T>` vs cast** — Must use `new NullLogger<T>()` not cast from `NullLoggerFactory.Instance.CreateLogger("Neatoo.Trace")` — the latter returns `ILogger`, not `ILogger<T>`.

--- a/docs/plans/completed/validatebase-logger-ilogger-t.memory/architect.md
+++ b/docs/plans/completed/validatebase-logger-ilogger-t.memory/architect.md
@@ -1,0 +1,42 @@
+# Architect -- ValidateBase Logger ILogger<T>
+
+Last updated: 2026-04-08
+Current step: Post-Implementation Verification
+
+## Architect Verification (Post-Implementation)
+
+### Verdict: VERIFIED
+
+### Build Results
+- `dotnet build src/Neatoo.sln` -- **0 errors, 0 warnings**
+
+### Test Results
+- `Neatoo.BaseGenerator.Tests.dll` -- 42 passed, 0 failed
+- `Samples.dll` -- 254 passed, 0 failed
+- `Neatoo.UnitTest.dll` -- 1789 passed, 0 failed, 2 skipped (pre-existing skips: FatClientValidate_Deserialize_SharedDictionaryReference, AsyncFlowTests_CheckAllRules)
+- `Person.DomainModel.Tests.dll` -- 55 passed, 0 failed
+- **Total: 2140 passed, 0 failed, 2 skipped**
+
+### Design Match Verification
+
+All 4 changed files match the plan's design:
+
+1. **`src/Neatoo/IValidateBaseServices.cs` (line 41)** -- `ILogger<T> Logger { get; }` -- matches plan. XML comment updated to reflect entity-type category.
+
+2. **`src/Neatoo/Internal/ValidateBaseServices.cs` (line 15)** -- Property type is `ILogger<T>`. All 5 constructors use `new NullLogger<T>()` as fallback (lines 26, 35, 45, 58). Constructor with `ILoggerFactory?` (line 72) uses `loggerFactory?.CreateLogger<T>() ?? new NullLogger<T>()`. Matches plan exactly.
+
+3. **`src/Neatoo/RemoteFactory/Internal/EntityBaseServices.cs`** -- Constructor with `ILoggerFactory` (line 64) uses `loggerFactory.CreateLogger<T>()`. Constructor with `ILoggerFactory?` (line 95) uses `loggerFactory?.CreateLogger<T>() ?? new NullLogger<T>()`. Other constructors inherit default `NullLogger<T>` from parent. Matches plan.
+
+4. **`src/Neatoo/ValidateBase.cs` (line 195)** -- `protected ILogger<T> Logger => Services.Logger;` -- matches plan.
+
+### Scope Verification -- No Other Files Need Changes
+
+- `Services.Logger` grep shows only one usage: `ValidateBase.cs:195` -- confirmed.
+- JSON converters (`NeatooBaseJsonTypeConverter`, `NeatooListBaseJsonTypeConverter`) create their own `"Neatoo.Trace"` loggers independently -- unaffected.
+- `NeatooTraceLog.cs` extension methods are on `ILogger` -- `ILogger<T> : ILogger` so they continue to work.
+- Source generator does not reference Logger -- no changes needed.
+
+## Key Context
+
+- This is a clean, minimal infrastructure change affecting 4 files
+- The 2 skipped tests are pre-existing and unrelated to this change

--- a/docs/plans/completed/validatebase-logger-ilogger-t.memory/developer.md
+++ b/docs/plans/completed/validatebase-logger-ilogger-t.memory/developer.md
@@ -1,0 +1,65 @@
+# Developer -- ValidateBase Logger ILogger<T>
+
+Last updated: 2026-04-08
+Current step: Post-Implementation Review
+
+## Key Context
+
+This is a straightforward infrastructure change: `ValidateBase<T>.Logger` goes from `ILogger` (category `"Neatoo.Trace"`) to `ILogger<T>` (category = entity type). Four files changed. JSON converters untouched. Source generator untouched.
+
+## Post-Implementation Review
+
+**Reviewed:** 2026-04-08
+**Feature:** Change ValidateBase<T>.Logger from ILogger to ILogger<T>
+
+### Production Code Review
+
+**Files examined:**
+
+1. **`src/Neatoo/IValidateBaseServices.cs`** -- Property type changed from `ILogger` to `ILogger<T>` on line 41. Correct.
+
+2. **`src/Neatoo/Internal/ValidateBaseServices.cs`** -- Property type changed to `ILogger<T>` on line 15. All five constructors updated:
+   - Lines 26, 35, 45, 58: `new NullLogger<T>()` -- correct, no cast needed
+   - Lines 72-73: `loggerFactory?.CreateLogger<T>() ?? new NullLogger<T>()` -- correct
+   - All assignments are consistent.
+
+3. **`src/Neatoo/RemoteFactory/Internal/EntityBaseServices.cs`** -- Inherits from `ValidateBaseServices<T>`. Three constructors that set Logger updated:
+   - Line 64: `loggerFactory.CreateLogger<T>()` -- correct (non-nullable loggerFactory here)
+   - Lines 95-96: `loggerFactory?.CreateLogger<T>() ?? new NullLogger<T>()` -- correct
+   - Two constructors (parameterless, IFactorySave-only) do NOT set Logger -- they inherit the `NullLogger<T>()` from `ValidateBaseServices` base constructor. Correct behavior.
+
+4. **`src/Neatoo/ValidateBase.cs`** line 195: `protected ILogger<T> Logger => Services.Logger;` -- correct type change.
+
+5. **`EntityBase.cs`** lines 561, 587: `Logger.FactoryCompleteStarted(...)` and `Logger.FactoryCompleteFinished(...)` -- these extension methods are defined on `ILogger` in `NeatooTraceLog.cs` (lines 114, 126). Since `ILogger<T> : ILogger`, these calls compile and work correctly. Verified.
+
+6. **JSON converters** (`NeatooBaseJsonTypeConverter.cs` line 25-26, `NeatooListBaseJsonTypeConverter.cs` line 22-23): Still use `CreateLogger("Neatoo.Trace")` independently. Unaffected. Verified.
+
+### Observations
+
+1. **Stale XML doc comment (minor)** -- Both `IValidateBaseServices.cs` (line 39) and `ValidateBase.cs` (line 193) still say: `Gets the trace-level logger for Neatoo framework diagnostics (category: "Neatoo.Trace").` This is now inaccurate -- the logger category is the entity type `T`, not `"Neatoo.Trace"`. The comment should be updated to reflect the new behavior (e.g., `Gets the logger for this entity type (category: typeof(T).FullName).`). **Non-blocking** but should be fixed before release.
+
+### Design Project Review
+
+`dotnet build src/Design/Design.sln` -- PASS. No design project files exercise the Logger property directly, which is expected since Logger is a protected member and Design project files test public API patterns.
+
+### Test Coverage Review
+
+All tests pass: 0 failed, 1789 passed (Neatoo.UnitTest), 254 passed (Samples), 42 passed (BaseGenerator.Tests), 55 passed (Person.DomainModel.Tests). 2 skipped tests are pre-existing.
+
+No new tests were added. This is acceptable -- the change is a type narrowing (`ILogger` to `ILogger<T>`) that doesn't alter runtime behavior for existing consumers. The existing tests implicitly validate that `NullLogger<T>` works correctly in all code paths.
+
+### Build Results
+
+- `dotnet build src/Neatoo.sln` -- PASS (0 warnings, 0 errors)
+- `dotnet build src/Design/Design.sln` -- PASS (0 warnings, 0 errors)
+- `dotnet test src/Neatoo.sln` -- PASS (all tests pass)
+
+### Verdict
+
+**Complete with one minor issue.**
+
+The implementation is correct and matches the plan. The only issue is stale XML doc comments in two locations that still reference `"Neatoo.Trace"` as the category, when the category is now the entity type name. This is cosmetic but should be corrected for accuracy.
+
+**Stale comment locations:**
+- `src/Neatoo/IValidateBaseServices.cs` line 39
+- `src/Neatoo/ValidateBase.cs` line 193

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Neatoo 0.27.0** (2026-04-06)
+**Neatoo 0.28.0** (2026-04-08)
 
 ---
 
@@ -12,6 +12,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date | Type | Summary |
 |---------|------|------|---------|
+| [0.28.0](v0.28.0.md) | 2026-04-08 | Feature | `Logger` is now `ILogger<T>` for consumer logging |
 | [0.27.0](v0.27.0.md) | 2026-04-06 | Feature | Field-level authorization via `MarkReadOnly()` |
 | [0.26.1](v0.26.1.md) | 2026-04-04 | Bug Fix | Hash-based rule IDs fix inheritance collision |
 | [0.24.0](v0.24.0.md) | 2026-03-23 | Feature | Private setter support in source generator; SetPrivateValue on IValidateProperty |
@@ -53,6 +54,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date |
 |---------|------|
+| [0.28.0](v0.28.0.md) | 2026-04-08 |
 | [0.27.0](v0.27.0.md) | 2026-04-06 |
 | [0.26.1](v0.26.1.md) | 2026-04-04 |
 | [0.24.0](v0.24.0.md) | 2026-03-23 |

--- a/docs/release-notes/v0.28.0.md
+++ b/docs/release-notes/v0.28.0.md
@@ -1,0 +1,60 @@
+# Neatoo 0.28.0
+
+**Release Date:** 2026-04-08
+**Type:** Minor
+**Breaking Changes:** Yes (minor — public interface change)
+
+---
+
+## Summary
+
+`ValidateBase<T>.Logger` is now `ILogger<T>` instead of `ILogger`. Consumers get a type-categorized logger they can use for application-level logging, replacing the previous framework-only `"Neatoo.Trace"` logger.
+
+---
+
+## What Changed
+
+### `Logger` Property: `ILogger` → `ILogger<T>`
+
+The `Logger` property on `ValidateBase<T>` (and by inheritance, `EntityBase<T>`) is now `ILogger<T>` where `T` is the consumer's entity type. Log output is categorized under the entity's type name instead of the hardcoded `"Neatoo.Trace"` category.
+
+**Before (0.27.0):**
+```csharp
+// Logger category: "Neatoo.Trace" — not useful for application logging
+protected ILogger Logger => Services.Logger;
+```
+
+**After (0.28.0):**
+```csharp
+// Logger category: "MyApp.Order" (or whatever T is) — standard .NET convention
+protected ILogger<T> Logger => Services.Logger;
+
+// Consumers can now log naturally:
+Logger.LogInformation("Order {Id} validated successfully", Id);
+```
+
+### Breaking Change: `IValidateBaseServices<T>.Logger`
+
+The `Logger` property on `IValidateBaseServices<T>` changed from `ILogger` to `ILogger<T>`. Anyone directly implementing this interface (rather than inheriting from `ValidateBaseServices<T>`) will need to update their implementation. This is unlikely since the interface is framework infrastructure.
+
+---
+
+## Migration
+
+If you directly implement `IValidateBaseServices<T>`:
+```csharp
+// Before
+public ILogger Logger { get; }
+
+// After
+public ILogger<T> Logger { get; }
+```
+
+If you inherit from `ValidateBaseServices<T>` or `EntityBaseServices<T>` (the normal case): no changes needed.
+
+---
+
+## Related
+
+- [v0.27.0 - Field-level authorization via MarkReadOnly()](v0.27.0.md)
+- [Completed todo](../todos/completed/validatebase-logger-ilogger-t.md)

--- a/docs/todos/completed/validatebase-logger-ilogger-t.md
+++ b/docs/todos/completed/validatebase-logger-ilogger-t.md
@@ -1,0 +1,110 @@
+# Investigate Making ValidateBase<T>.Logger an ILogger<T>
+
+**Status:** Complete
+**Priority:** Low
+**Created:** 2026-04-08
+**Last Updated:** 2026-04-08
+
+
+---
+
+## Problem
+
+`ValidateBase<T>.Logger` is currently `ILogger` (non-generic), always created with the category `"Neatoo.Trace"`. Consumers cannot use it for their own application-level logging because:
+
+1. The category is hardcoded to `"Neatoo.Trace"` — all consumer log messages would appear under the framework's trace category, making filtering impossible
+2. The type is `ILogger`, not `ILogger<T>` — consumers lose the standard .NET convention of type-categorized loggers
+
+If the logger were `ILogger<T>` (where `T` is the consumer's entity type), consumers could use it naturally for domain logging (e.g., `Logger.LogInformation("Order {Id} validated", Id)`) and the log output would be categorized under their type (e.g., `MyApp.Order`).
+
+### Current Implementation
+
+- `IValidateBaseServices<T>.Logger` → `ILogger` (line 41 of `IValidateBaseServices.cs`)
+- `ValidateBaseServices<T>.Logger` → set via `ILoggerFactory.CreateLogger("Neatoo.Trace")` (lines 26, 35, 45, 58, 72)
+- `EntityBaseServices<T>` → same pattern, inherits from `ValidateBaseServices<T>` (lines 64, 95)
+- `ValidateBase<T>.Logger` → `protected ILogger Logger => Services.Logger;` (line 195)
+
+## Solution
+
+Investigate whether the Logger can be changed to `ILogger<T>` so that:
+- Consumers get a logger categorized to their entity type
+- Framework trace logging uses a separate internal logger (not exposed to consumers)
+- The DI registration continues to work with `ILoggerFactory`
+
+### Key Questions to Resolve
+
+1. **Separation of concerns** — Should there be two loggers? One internal `ILogger` for Neatoo trace (property changes, rule execution) and one `ILogger<T>` for consumer use? Or should the consumer logger replace the trace logger entirely?
+2. **DI impact** — `ILoggerFactory.CreateLogger<T>()` requires knowing `T` at service construction time. The services already have `T` as a type parameter, so this should work. Verify.
+3. **Breaking change assessment** — Changing `ILogger` to `ILogger<T>` on the interface is a breaking change for anyone implementing `IValidateBaseServices<T>` directly (unlikely but possible).
+4. **Source generator impact** — Does the generated code reference the Logger? If so, does it need updating?
+5. **Serialization/deserialization** — `NeatooBaseJsonTypeConverter` creates its own `"Neatoo.Trace"` logger. This is separate and should remain unchanged.
+
+---
+
+## Requirements Review
+
+**Reviewer:** [pending]
+**Reviewed:** [pending]
+**Verdict:** Pending
+
+### Relevant Requirements Found
+
+[Pending]
+
+### Gaps
+
+[Pending]
+
+### Contradictions
+
+[Pending]
+
+### Recommendations for Architect
+
+[Pending]
+
+---
+
+## Plans
+
+- [Change ValidateBase<T>.Logger from ILogger to ILogger<T>](../plans/validatebase-logger-ilogger-t.md)
+
+---
+
+## Tasks
+
+- [x] Implementation
+- [x] Developer code review — approved
+- [x] Architect verification — VERIFIED
+
+---
+
+## Progress Log
+
+### 2026-04-08
+- Created todo to investigate `ILogger<T>` for consumer logging
+- Documented current implementation: `ILogger` with hardcoded `"Neatoo.Trace"` category in `ValidateBaseServices<T>` and `EntityBaseServices<T>`
+- Identified key questions around separation of trace vs consumer logging, DI impact, and breaking changes
+
+---
+
+## Completion Verification
+
+Before marking this todo as Complete, verify:
+
+- [x] All builds pass
+- [x] All tests pass
+
+**Verification results:**
+- Build: 0 errors
+- Tests: 2140 passed, 0 failed, 2 skipped (pre-existing)
+
+---
+
+## Results / Conclusions
+
+- **One `ILogger<T>` is sufficient** — no need for a separate framework trace logger
+- Only 2 framework log calls used `Services.Logger` (both in `EntityBase.FactoryComplete`), and they use structured EventIds so category change doesn't affect filterability
+- Serialization loggers (`NeatooBaseJsonTypeConverter`, `NeatooListBaseJsonTypeConverter`) create their own independent `"Neatoo.Trace"` loggers — unaffected
+- Source generator doesn't reference Logger — no generator changes needed
+- Changed 4 files: `IValidateBaseServices.cs`, `ValidateBaseServices.cs`, `EntityBaseServices.cs`, `ValidateBase.cs`

--- a/src/Neatoo/IValidateBaseServices.cs
+++ b/src/Neatoo/IValidateBaseServices.cs
@@ -36,9 +36,9 @@ public interface IValidateBaseServices<[DynamicallyAccessedMembers(DynamicallyAc
     IPropertyFactory<T> PropertyFactory { get; }
 
     /// <summary>
-    /// Gets the trace-level logger for Neatoo framework diagnostics (category: "Neatoo.Trace").
+    /// Gets the logger for this entity type (category: the entity's type name).
     /// </summary>
-    ILogger Logger { get; }
+    ILogger<T> Logger { get; }
 
     /// <summary>
     /// Creates a new rule manager for the specified target object.

--- a/src/Neatoo/Internal/ValidateBaseServices.cs
+++ b/src/Neatoo/Internal/ValidateBaseServices.cs
@@ -12,7 +12,7 @@ public class ValidateBaseServices<[DynamicallyAccessedMembers(DynamicallyAccesse
     public IPropertyInfoList<T> PropertyInfoList { get; protected set; }
     public IValidatePropertyManager<IValidateProperty> ValidatePropertyManager { get; }
     public IPropertyFactory<T> PropertyFactory { get; protected set; }
-    public ILogger Logger { get; protected set; }
+    public ILogger<T> Logger { get; protected set; }
 
     public RuleManagerFactory<T> ruleManagerFactory { get; protected set; }
 
@@ -23,7 +23,7 @@ public class ValidateBaseServices<[DynamicallyAccessedMembers(DynamicallyAccesse
         this.ValidatePropertyManager = new ValidatePropertyManager<IValidateProperty>(PropertyInfoList, factory);
         this.PropertyFactory = new DefaultPropertyFactory<T>(PropertyInfoList, factory);
         this.ruleManagerFactory = new RuleManagerFactory<T>(new AttributeToRule());
-        this.Logger = NullLoggerFactory.Instance.CreateLogger("Neatoo.Trace");
+        this.Logger = new NullLogger<T>();
     }
 
     public ValidateBaseServices(IPropertyInfoList<T> propertyInfoList, RuleManagerFactory<T> createRuleManager)
@@ -32,7 +32,7 @@ public class ValidateBaseServices<[DynamicallyAccessedMembers(DynamicallyAccesse
         var factory = new DefaultFactory();
         this.PropertyFactory = new DefaultPropertyFactory<T>(PropertyInfoList, factory);
         this.ruleManagerFactory = createRuleManager;
-        this.Logger = NullLoggerFactory.Instance.CreateLogger("Neatoo.Trace");
+        this.Logger = new NullLogger<T>();
     }
 
     public ValidateBaseServices(CreateValidatePropertyManager validatePropertyManager, IPropertyInfoList<T> propertyInfoList, RuleManagerFactory<T> createRuleManager)
@@ -42,7 +42,7 @@ public class ValidateBaseServices<[DynamicallyAccessedMembers(DynamicallyAccesse
         ValidatePropertyManager = validatePropertyManager(PropertyInfoList);
         this.PropertyFactory = new DefaultPropertyFactory<T>(PropertyInfoList, factory);
         this.ruleManagerFactory = createRuleManager;
-        this.Logger = NullLoggerFactory.Instance.CreateLogger("Neatoo.Trace");
+        this.Logger = new NullLogger<T>();
     }
 
     public ValidateBaseServices(
@@ -55,7 +55,7 @@ public class ValidateBaseServices<[DynamicallyAccessedMembers(DynamicallyAccesse
         ValidatePropertyManager = validatePropertyManager(PropertyInfoList);
         this.PropertyFactory = propertyFactory;
         this.ruleManagerFactory = createRuleManager;
-        this.Logger = NullLoggerFactory.Instance.CreateLogger("Neatoo.Trace");
+        this.Logger = new NullLogger<T>();
     }
 
     public ValidateBaseServices(
@@ -69,8 +69,8 @@ public class ValidateBaseServices<[DynamicallyAccessedMembers(DynamicallyAccesse
         ValidatePropertyManager = validatePropertyManager(PropertyInfoList);
         this.PropertyFactory = propertyFactory;
         this.ruleManagerFactory = createRuleManager;
-        this.Logger = loggerFactory?.CreateLogger("Neatoo.Trace")
-            ?? NullLoggerFactory.Instance.CreateLogger("Neatoo.Trace");
+        this.Logger = loggerFactory?.CreateLogger<T>()
+            ?? new NullLogger<T>();
     }
 
     public IRuleManager<T> CreateRuleManager(T target)

--- a/src/Neatoo/RemoteFactory/Internal/EntityBaseServices.cs
+++ b/src/Neatoo/RemoteFactory/Internal/EntityBaseServices.cs
@@ -61,7 +61,7 @@ public class EntityBaseServices<[DynamicallyAccessedMembers(DynamicallyAccessedM
         var internalFactory = new DefaultFactory();
         this.EntityPropertyManager = propertyManager(propertyInfoList);
         this.PropertyFactory = new EntityPropertyFactory<T>(propertyInfoList, internalFactory);
-        this.Logger = loggerFactory.CreateLogger("Neatoo.Trace");
+        this.Logger = loggerFactory.CreateLogger<T>();
     }
 
     public EntityBaseServices(
@@ -92,7 +92,7 @@ public class EntityBaseServices<[DynamicallyAccessedMembers(DynamicallyAccessedM
         this.EntityPropertyManager = propertyManager(propertyInfoList);
         this.PropertyFactory = new EntityPropertyFactory<T>(propertyInfoList, internalFactory);
         this.Factory = factory;
-        this.Logger = loggerFactory?.CreateLogger("Neatoo.Trace")
-            ?? NullLoggerFactory.Instance.CreateLogger("Neatoo.Trace");
+        this.Logger = loggerFactory?.CreateLogger<T>()
+            ?? new NullLogger<T>();
     }
 }

--- a/src/Neatoo/ValidateBase.cs
+++ b/src/Neatoo/ValidateBase.cs
@@ -190,9 +190,9 @@ public abstract class ValidateBase<[DynamicallyAccessedMembers(DynamicallyAccess
 	protected IValidateBaseServices<T> Services { get; private set; }
 
 	/// <summary>
-	/// Gets the trace-level logger for Neatoo framework diagnostics (category: "Neatoo.Trace").
+	/// Gets the logger for this entity type (category: the entity's type name).
 	/// </summary>
-	protected ILogger Logger => Services.Logger;
+	protected ILogger<T> Logger => Services.Logger;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ValidateBase{T}"/> class.


### PR DESCRIPTION
## Summary

- Change `ValidateBase<T>.Logger` from `ILogger` (category `"Neatoo.Trace"`) to `ILogger<T>` (category = entity type name)
- Consumers can now use `Logger` for application-level logging with proper type-categorized output
- Bump version to 0.28.0

## Test plan

- [x] All 2098 tests pass (0 failed, 2 skipped pre-existing)
- [x] Build succeeds with 0 errors
- [ ] Verify consumer can call `Logger.LogInformation(...)` and see output under their entity type's category

🤖 Generated with [Claude Code](https://claude.com/claude-code)