### PR TITLE
fix: PropertyInfoWrapper thread-safety; bump 0.28.1; RemoteFactory 1.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>0.28.0</Version>
+		<Version>0.28.1</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="MudBlazor" Version="9.0.0" />
     <!-- Neatoo Dependencies -->
     <PackageVersion Include="Neatoo" Version="9.10.1" />
-    <PackageVersion Include="Neatoo.RemoteFactory" Version="0.29.0" />
-    <PackageVersion Include="Neatoo.RemoteFactory.AspNetCore" Version="0.29.0" />
+    <PackageVersion Include="Neatoo.RemoteFactory" Version="1.1.0" />
+    <PackageVersion Include="Neatoo.RemoteFactory.AspNetCore" Version="1.1.0" />
     <!-- Testing - MSTest -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />

--- a/docs/plans/propertyinfowrapper-thread-safety.md
+++ b/docs/plans/propertyinfowrapper-thread-safety.md
@@ -1,0 +1,193 @@
+# PropertyInfoWrapper Thread Safety — Plan
+
+**Date:** 2026-04-12
+**Related Todo:** [PropertyInfoWrapper Thread Safety — Concurrent Dictionary Corruption](../todos/propertyinfowrapper-thread-safety.md)
+**Status:** Awaiting Code Review
+**Last Updated:** 2026-04-12
+
+---
+
+## Overview
+
+`PropertyInfoWrapper` instances are, by design, shared across all threads and all DI scopes in a running process (via `PropertyInfoList<T>.PropertyInfos`, a `static` dictionary on a singleton-lifetime list type). Property metadata is immutable at runtime, so this is the correct design. But the wrapper's two lazy caches — `customAttribute` (a `Dictionary<Type, Attribute?>`) and `customAttributes` (a `List<Attribute>?`) — are populated without synchronization. Concurrent entity construction racing on the dictionary corrupts it and produces `InvalidOperationException` from `Dictionary.set_Item` for every subsequent caller until process restart.
+
+This plan makes both caches thread-safe by serializing access behind an instance-level `lock`, matching the pattern already established in `PropertyInfoList<T>.RegisterProperties`. It also adds concurrent regression tests that deterministically reproduce the corruption against the current code.
+
+---
+
+## Skills
+
+- `~/.claude/skills/neatoo/SKILL.md` — framework patterns, `PropertyInfoWrapper` role in the property system, `PropertyInfoList<T>` lifetime, test conventions (no mocking Neatoo classes, MSTest `[TestClass]`/`[TestMethod]`, naming `MethodName_Scenario_ExpectedResult`)
+
+---
+
+## Business Rules (Testable Assertions)
+
+1. WHEN N threads concurrently call `PropertyInfoWrapper.GetCustomAttribute<TAttr>()` on the same wrapper instance for the same or different `TAttr` types, THEN no call throws and the internal cache state remains consistent (no `InvalidOperationException` from `Dictionary`). — Source: NEW
+2. WHEN N threads concurrently call `PropertyInfoWrapper.GetCustomAttributes()` on the same wrapper instance, THEN no call throws and all calls return references to `List<Attribute>` instances containing the complete attribute set. — Source: NEW
+3. WHEN `GetCustomAttribute<TAttr>()` is called repeatedly on the same wrapper for the same `TAttr`, THEN all calls return the same `TAttr` instance (reference equality preserved). — Source: existing test `GetCustomAttribute_CalledTwice_ReturnsSameInstance` at `src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs:478`
+4. WHEN `GetCustomAttribute<TAttr>()` is called on a property that does not have `TAttr`, THEN the result is `null` and subsequent calls do not re-invoke `PropertyInfo.GetCustomAttribute<TAttr>()`. — Source: existing test `GetCustomAttribute_NullResult_IsCached` at `src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs:512`
+5. WHEN `GetCustomAttributes()` is called repeatedly on the same wrapper, THEN all calls return the same collection reference. — Source: existing test `GetCustomAttributes_CalledTwice_ReturnsSameCollection` at `src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs:549`
+6. WHEN different `TAttr` types are requested on the same wrapper, THEN each type's result is cached independently and subsequent calls return the cached value per type. — Source: existing test `GetCustomAttribute_DifferentAttributeTypes_CachedSeparately` at `src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs:529`
+
+### Test Scenarios
+
+| # | Scenario | Inputs / State | Rule(s) | Expected Result |
+|---|----------|---------------|---------|-----------------|
+| 1 | Concurrent single-type attribute lookup reproduces corruption on current code, passes after fix | 64 threads x 10,000 iterations, single shared wrapper, all threads request the same `TAttr`; cold cache at t=0 | Rule 1 | Current code: `InvalidOperationException` from `Dictionary.set_Item` within the first few hundred iterations. Fixed code: all 640,000 calls complete without exception; all return the same attribute instance. |
+| 2 | Concurrent multi-type attribute lookup under contention | 64 threads x 10,000 iterations, single shared wrapper, each iteration randomly picks one of 8 `TAttr` types (some present on the property, some not); cold cache at t=0 | Rule 1, Rule 4, Rule 6 | Fixed code: all calls succeed; each attribute type returns the same cached instance (or `null`) across all threads; reflection invoked at most once per type. |
+| 3 | Concurrent `GetCustomAttributes()` stress | 64 threads x 10,000 iterations, single shared wrapper, all threads call `GetCustomAttributes()`; cold cache at t=0 | Rule 2, Rule 5 | Fixed code: all calls succeed; all return the same `List<Attribute>` reference after first population; list contents match serial baseline. |
+| 4 | Repeated calls return same instance (existing behavior preserved) | Single thread, repeated `GetCustomAttribute<T>()` | Rule 3 | `AreSame` holds across calls. Existing test `GetCustomAttribute_CalledTwice_ReturnsSameInstance` still passes. |
+| 5 | Null result caching (existing behavior preserved) | Property without `TAttr`, repeated `GetCustomAttribute<TAttr>()` | Rule 4 | Returns `null`; reflection invoked at most once. Existing test `GetCustomAttribute_NullResult_IsCached` still passes. |
+| 6 | `GetCustomAttributes()` returns same reference (existing behavior preserved) | Single thread, repeated `GetCustomAttributes()` | Rule 5 | `AreSame` across calls. Existing test `GetCustomAttributes_CalledTwice_ReturnsSameCollection` still passes. |
+| 7 | Different attribute types cached separately (existing behavior preserved) | Single thread, interleaved calls for two `TAttr` types | Rule 6 | Each type returns its own cached instance; cross-type cache isolation holds. Existing test `GetCustomAttribute_DifferentAttributeTypes_CachedSeparately` still passes. |
+| 8 | Shared-wrapper sanity — same `PropertyInfoWrapper` returned across DI resolutions | Resolve `IPropertyInfoList<TSomeTestType>` twice from DI; call `GetPropertyInfo("SomeProp")` on both | Underpins Rules 1, 2 (thread-safety is only needed because wrappers are shared) | Both resolutions return `AreSame` `IPropertyInfo` references; underlying `PropertyInfoWrapper` is also `AreSame`. Passes on both current and fixed code. If this test ever fails, the wrapper-sharing invariant is broken and the thread-safety contract scope has changed — a signal for review, not a silent pass. |
+
+---
+
+## Approach
+
+Serialize access to both `PropertyInfoWrapper` caches behind a single instance-level `lock` object. Reflection inside the lock is invoked at most once per attribute type (for `customAttribute`) and at most once total (for `customAttributes`). The lock is only contended during cache warm-up; once populated, readers still acquire the lock but the critical section is a dictionary lookup or reference read — microseconds, no reflection.
+
+This matches the pattern already used in `PropertyInfoList<T>.RegisterProperties` (single `static` lock object guarding lazy population), so the fix is idiomatic for this codebase.
+
+### Rejected alternatives (for completeness)
+
+- **`ConcurrentDictionary` + `GetOrAdd`** — works but allows the reflection factory to run multiple times under contention. Rejected in favor of "exactly-once reflection" and consistency with the `RegisterProperties` pattern.
+- **`Lazy<Attribute?>` per type in a `ConcurrentDictionary`** — strongest guarantee but higher per-type allocation. Not needed here.
+- **Double-checked locking with `volatile`** — more complex than a simple lock; no measurable benefit given cache is populated quickly and contention is low post-warm-up.
+
+---
+
+## Domain Model Behavioral Design
+
+Not applicable. This plan modifies a framework-internal reflection cache, not a domain model. No computed properties, visibility flags, reactive rules, classification properties, or validation rules are introduced or changed.
+
+---
+
+## Design
+
+### File changes
+
+- `src/Neatoo/Internal/PropertyInfoWrapper.cs` — modify `GetCustomAttribute<T>()` and `GetCustomAttributes()`; add instance-level `lock` object
+- `src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs` — add concurrent regression tests (new `#region Thread Safety Tests` section)
+
+### Code shape
+
+```csharp
+public class PropertyInfoWrapper : IPropertyInfo
+{
+    private readonly object cacheLock = new object();
+
+    private Dictionary<Type, Attribute?> customAttribute = new();
+
+    // Virtual seam: test-only subclass overrides this to count reflection invocations.
+    // Production code calls this from inside the lock exactly once per attribute type.
+    protected virtual Attribute? ReflectCustomAttribute(Type attrType)
+        => this.PropertyInfo.GetCustomAttribute(attrType);
+
+    public T? GetCustomAttribute<T>() where T : Attribute
+    {
+        lock (cacheLock)
+        {
+            if (!this.customAttribute.ContainsKey(typeof(T)))
+            {
+                this.customAttribute[typeof(T)] = ReflectCustomAttribute(typeof(T));
+            }
+            return (T?)this.customAttribute[typeof(T)];
+        }
+    }
+
+    private List<Attribute>? customAttributes;
+
+    public IEnumerable<Attribute> GetCustomAttributes()
+    {
+        lock (cacheLock)
+        {
+            if (this.customAttributes == null)
+            {
+                this.customAttributes = this.PropertyInfo.GetCustomAttributes().ToList();
+            }
+            // Safe to return while other threads hold references: the list is assigned exactly
+            // once on first population and is never mutated afterward. Callers enumerate outside
+            // the lock, but since the list reference is stable and its contents are immutable
+            // post-assignment, no torn reads are possible.
+            return this.customAttributes;
+        }
+    }
+}
+```
+
+**Invariant (must not be violated by future refactors):** the `customAttribute` dictionary reference and the `customAttributes` list reference, once assigned, are never replaced. Only their contents are mutated, and only inside the lock, and only during the cold→warm transition. Any future change that reassigns either field outside the lock (for example, a well-meaning "clear cache" API) reintroduces the race.
+
+### Single lock vs. two locks
+
+Use one `cacheLock` for both caches. The two caches are accessed from different call sites (rule engines look up specific attribute types; list consumers enumerate all), and lock contention between them is near-zero in practice. A single lock is simpler and removes a coordination question.
+
+### Lock scope
+
+The lock is an **instance** field, not `static`. Each `PropertyInfoWrapper` has its own lock. Threads accessing different wrappers do not contend. Threads accessing the same wrapper serialize briefly inside the critical section — acceptable because the section is a dictionary lookup, not I/O.
+
+### Test design
+
+- **Framework:** MSTest (match existing test conventions).
+- **Concurrency primitive:** `Parallel.For` with `MaxDegreeOfParallelism = 64` for the stress loop; `ManualResetEventSlim` as a starting gate (`gate.Wait()` at the top of each worker, `gate.Set()` after all threads have been scheduled) so all threads hit the wrapper simultaneously — maximizes race probability on cold cache.
+- **Iteration count:** 10,000 per thread (640,000 total calls per scenario) — chosen empirically; the `Dictionary` corruption window is extremely narrow, so high iteration counts are needed to hit it reliably on current code.
+- **Wrapper instance per scenario (explicit):** each test method constructs **exactly one** `PropertyInfoWrapper` instance at the start of the test, shared by all 64 threads for all 10,000 iterations. The wrapper begins with a cold cache (fresh `Dictionary`/`List` fields from the constructor). The wrapper is NOT reset between iterations — a single cold→warm transition per test method is what triggers the race. This matches the production path: one long-lived wrapper hit by many threads during warm-up.
+- **Why one-wrapper-per-test (not one-per-iteration):** the corruption is persistent — once the `Dictionary` is corrupted, every subsequent `set_Item` throws forever. On unmodified code, the test should throw within the first few hundred iterations (first cold-cache race). On fixed code, the test should complete all 640k calls without exception. Resetting the wrapper between iterations would hide multi-thread-interleave corruption that only shows up after a long run; keeping one wrapper maximizes contention on the single `_version` field and most faithfully models production.
+- **Reflection-count measurement (Scenario 2):** to verify "reflection invoked at most once per attribute type" (the core property that `lock` buys over `ConcurrentDictionary.GetOrAdd`), introduce a **test-only subclass** `CountingPropertyInfoWrapper : PropertyInfoWrapper` that overrides a virtual `ReflectCustomAttribute<T>()` seam (added to `PropertyInfoWrapper` for this purpose — see Design section below) and increments an atomic `ConcurrentDictionary<Type, int>` counter per invocation. After the stress run, assert every entry in the counter equals exactly 1. If `PropertyInfoWrapper` cannot be made subclassable without a larger refactor, alternate: wrap a custom `PropertyInfo`-derived type whose `GetCustomAttribute` increments a counter. Implementer picks the cleaner path and records the choice in the developer memory file. Scenarios 1 and 3 do not require counting — they only assert zero exceptions.
+- **Random seeding (Scenario 2):** Scenario 2 picks 1 of 8 attribute types per iteration. Use a per-thread `Random` seeded deterministically: `new Random(12345 + Thread.CurrentThread.ManagedThreadId)` or pass a `ThreadLocal<Random>` that derives the seed from a fixed base. Do **not** share a single `Random` across threads — `System.Random` is not thread-safe and will itself throw, producing a confusing failure unrelated to the bug under test. Do **not** use `Random.Shared` without noting it — while thread-safe, it obscures reproducibility.
+- **Reproducibility baseline:** before writing the fix, run the new tests against unmodified `PropertyInfoWrapper.cs` and confirm they fail. Capture the first failure output (exception type, message, stack) and paste it into the developer memory file in Step 1 immediately after the baseline run — waiting until Step 5 risks losing the evidence if the test is edited mid-flight. Without this baseline, we cannot claim the tests prove the fix works.
+- **Shared-wrapper sanity check (Scenario 8 — see Test Scenarios table):** include one short test that resolves `IPropertyInfoList<TSomeTestType>` from the DI container twice, calls `GetPropertyInfo("SomeProp")` on each result, and asserts `Assert.AreSame` on the returned `IPropertyInfo` references (and, after casting, on the underlying `PropertyInfoWrapper`). This codifies the "shared by design" invariant directly at the `PropertyInfoList<T>` level — no `EntityProperty<P>` indirection needed, since the sharing happens in the list's static dictionary. A future refactor that accidentally makes wrappers per-scope would fail this test and signal that the thread-safety contract no longer applies.
+
+---
+
+## Implementation Steps
+
+1. **Write concurrent regression tests first.** Add new `#region Thread Safety Tests` in `PropertyInfoWrapperTests.cs` covering Scenarios 1, 2, 3. Each test constructs one wrapper, one starting-gate `ManualResetEventSlim`, and runs `Parallel.For` with `MaxDegreeOfParallelism = 64`. Scenario 2 uses a `CountingPropertyInfoWrapper` subclass (or equivalent counter harness — see Test design) and asserts every per-type counter equals 1. Run the tests against the **unmodified** `PropertyInfoWrapper.cs` — tests must fail with `InvalidOperationException` from `Dictionary`. **Immediately** paste the first failure output (exception type, message, top of stack) into the developer memory file at `docs/plans/propertyinfowrapper-thread-safety.memory/developer.md` under a heading `## Baseline Failure Output (pre-fix)`. If tests pass against unmodified code, the reproducer is insufficient — raise iteration count or thread count until they fail deterministically before continuing to Step 2.
+2. **Add Scenario 8 (shared-wrapper sanity test).** Resolve `IPropertyInfoList<TSomeTestType>` from the DI container twice, call `GetPropertyInfo("SomeProp")` on both, `Assert.AreSame` on the `IPropertyInfo` references, and cast to `PropertyInfoWrapper` and `Assert.AreSame` again. Do **not** route through `EntityProperty<P>` — the sharing happens at the `PropertyInfoList<T>` level, and going through `EntityProperty<P>` adds unnecessary DI setup. Run against current code — should pass (confirms the sharing invariant exists today).
+3. **Modify `PropertyInfoWrapper.cs`:** add `private readonly object cacheLock = new object();`. Wrap the bodies of `GetCustomAttribute<T>()` and `GetCustomAttributes()` in `lock (cacheLock) { ... }`.
+4. **Rerun concurrent regression tests.** All scenarios (1, 2, 3) must now pass. Run each test 3 times in a row to confirm stability.
+5. **Rerun full `PropertyInfoWrapperTests` class.** All existing tests (Scenarios 4, 5, 6, 7 — existing caching, IsPrivateSetter, Type, etc.) must still pass.
+6. **Rerun full Neatoo test suite:** `dotnet test src/Neatoo.sln`. Zero failures.
+7. **Audit adjacent caches.** Run the following concrete searches against `src/Neatoo/**/*.cs` (not tests):
+   - **Search A — unsynchronized lazy dictionaries:** `private (static )?(readonly )?Dictionary<` followed by nullable/lazy-populate usage. Ripgrep pattern: `private.*Dictionary<.*>.*=.*new\(\)` and inspect each hit for (i) whether the enclosing type is registered as Singleton in `AddNeatooServices.cs`, (ii) whether the dictionary is written inside a method without a lock. Singleton-reachable + unsynchronized write = same bug as `PropertyInfoWrapper`.
+   - **Search B — unsynchronized lazy list/reference caches:** `private (static )?List<.*>\?` and `private (static )?IEnumerable<.*>\?`, looking for the `if (field == null) { field = Build(); } return field;` pattern.
+   - **Search C — `isRegistered`-style one-time-init flags:** `private (static )?bool [a-zA-Z]+ = false;` paired with a populate method. These should already be lock-guarded (as in `PropertyInfoList<T>.RegisterProperties`), but verify every read path takes the lock or is safe by other means.
+   - **Target files to check explicitly** (from the skim of the singleton surface and the `remove-inconsistent-locks.md` context): `src/Neatoo/Rules/RuleManager.cs`, `src/Neatoo/Rules/AttributeToRule.cs`, `src/Neatoo/Internal/PropertyInfoList.cs` (already partially locked — verify read paths through `GetPropertyInfo`/`HasProperty`/`Properties()` are safe after registration completes), `src/Neatoo/Internal/PropertyManager*.cs`, `src/Neatoo/Internal/ValidatePropertyManager.cs`, `src/Neatoo/Internal/EntityPropertyManager*.cs`. Add any newly discovered singleton-reachable cache types to this list.
+   - **Output:** document every file searched, each hit's location, and a verdict (safe / needs-fix / ambiguous-deferred) in the developer memory file under `## Adjacent Cache Audit`. Cross-reference `docs/todos/remove-inconsistent-locks.md` where overlap exists.
+   - If the audit finds new bugs, raise them to the orchestrator; do not silently fix them within this plan's scope.
+8. **Add release notes entry** under `docs/release-notes/` (next patch version — bug fix). Entry must name the exception, the stack site, and the public contract being affirmed (thread-safe attribute lookup on shared wrappers).
+
+---
+
+## Acceptance Criteria
+
+- [ ] New concurrent regression tests added at `src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs`, covering Scenarios 1, 2, 3
+- [ ] Regression tests verified to fail against unmodified code (failure output captured to developer memory file), then pass after the fix (stability: 3 consecutive clean runs)
+- [ ] Scenario 2 reflection-count assertion passes: every attribute type in the counter dictionary equals exactly 1 after the stress run (proves "exactly-once reflection" — the lock's value over `ConcurrentDictionary.GetOrAdd`)
+- [ ] Scenario 8 (shared-wrapper sanity — defined in the Test Scenarios table) added and passes on both current and fixed code
+- [ ] All existing `PropertyInfoWrapperTests` still pass
+- [ ] `dotnet build src/Neatoo.sln` succeeds with `TreatWarningsAsErrors=true`
+- [ ] `dotnet test src/Neatoo.sln` green
+- [ ] Adjacent-cache audit documented (findings, fixes-or-new-todos decisions) in the developer memory file
+- [ ] Release notes entry added under `docs/release-notes/`
+- [ ] No behavioral changes to caching contract: same attribute instance returned on repeat calls (Rule 3); null cached (Rule 4); same list reference returned (Rule 5); different attribute types cached independently (Rule 6)
+
+---
+
+## Dependencies
+
+- No external dependencies. Fix is contained entirely in `Neatoo` core and its unit test project.
+- No Neatoo.BaseGenerator, Neatoo.Analyzers, or RemoteFactory changes required.
+- Verification consumers (zTreatment) do not need coordination — they consume the NuGet package; shipping a patch version is sufficient.
+
+---
+
+## Risks / Considerations
+
+- **Lock contention under extreme load.** Serializing all attribute lookups through a single instance lock creates a bottleneck if the same wrapper is hit by thousands of threads. In practice the critical section is a dictionary lookup on a populated cache — nanoseconds — so this is not a realistic concern for the production workload described in the todo. If profiling later shows contention, switch to `ConcurrentDictionary<Type, Attribute?>` with `GetOrAdd` — that is a self-contained follow-up change.
+- **Test flakiness on slow CI hardware.** Concurrent regression tests that depend on racing threads can hide real failures if the CI box is single-core or slow. Mitigate by setting `MaxDegreeOfParallelism` explicitly and using a `ManualResetEventSlim` starting gate so all threads launch simultaneously rather than staggering. If flakiness still occurs, raise iteration count or run tests in a loop with `[TestMethod]` helpers.
+- **Verifying the regression test actually reproduces the bug.** If the test passes against unmodified `PropertyInfoWrapper.cs`, the test is insufficient. Step 1 of the implementation requires confirmation that the test fails against the current code before the fix is written. This is a non-negotiable prerequisite.
+- **Adjacent caches might reveal deeper issues.** The audit step (task list in todo) may find similar patterns elsewhere. If the audit uncovers new bugs, file them as separate todos; do not expand this plan's scope.
+- **The `List<Attribute>?` cache field was never corrupting on current code.** Hardening it here is defensive, not bug-fixing. The cost is negligible (one added `lock`), and the consistency benefit (both caches follow the same rule) outweighs the alternative of leaving mismatched concurrency stories in one file.

--- a/docs/plans/propertyinfowrapper-thread-safety.memory/developer.md
+++ b/docs/plans/propertyinfowrapper-thread-safety.memory/developer.md
@@ -1,0 +1,134 @@
+# Developer Pre-Implementation Review — PropertyInfoWrapper Thread Safety
+
+**Date:** 2026-04-12
+**Reviewer:** neatoo-developer
+**Review type:** Pre-implementation plan grading (not Step 5 code review)
+
+## Composite Grade: B+
+
+The plan correctly diagnoses the bug, chooses a defensible fix, and enumerates existing regression cases well. It is let down by an under-specified stress-test design (no cache-reset between iterations, no seed, no per-test fresh wrapper semantics stated), an acceptance criterion that refers to a scenario number that does not exist, and a vague "audit adjacent caches" step that any implementer will interpret differently. With the must-fixes below it is a clean Grade A.
+
+## Dimensional Grades
+
+| Dimension | Grade | One-sentence reasoning |
+|-----------|-------|------------------------|
+| Bug understanding | A | Root cause correct: static `PropertyInfoList<T>.PropertyInfos` holds the wrapper, `ContainsKey`+`set_Item` on `Dictionary<,>` is non-atomic, `_version` check throws on race, corrupted dictionary stays broken. |
+| Scope discipline | B | Scope is right (wrapper only, plus regression tests + audit), but the `customAttributes` list is included "for consistency" without grading the value — and the audit step is loose enough to creep. |
+| Business rules / testable assertions | B+ | Rules 1-6 are unambiguous and traced. Missing: an explicit rule for "reflection invoked at most once per `TAttr`" which Scenario 2 implicitly expects — a junior could skip enforcing it. Rule 2 says "references to `List<Attribute>` instances" (plural) but Rule 5 says "same collection reference" (singular) — contradiction on first read. |
+| Test strategy | C+ | Biggest weakness. The plan does not address three concrete reproducibility issues: (a) whether each `Parallel.For` iteration resets the wrapper cache or shares one wrapper across 640k calls (if shared, the first race corrupts once and every subsequent call throws — proving nothing about the fix's correctness on a fresh cache), (b) no `Random` seed for Scenario 2's 8-type pick (flaky), (c) no mention of whether `Parallel.For`'s `MaxDegreeOfParallelism = 64` on a CI box with 2 cores actually races — thread-count != core-count doesn't guarantee interleaving on cold cache without the starting gate, which the plan mentions but does not specify how to construct. |
+| Fix design correctness | A- | The lock closes every race. All reads and writes of `customAttribute` / `customAttributes` are inside the lock. Returning `this.customAttributes` from inside the lock and enumerating outside is safe because the list is written once, never mutated after population — but the plan does not state this reasoning, which is the sort of thing a reviewer should want written down. Shape shown in Design section is correct. |
+| Implementation steps | B | Order is right (test first, verify failure, fix, verify pass). Step 7 ("audit adjacent caches") is too vague — no search pattern, no concrete target list beyond the todo's list. Step 2 adds the sanity test but doesn't name the DI entry point (`IPropertyInfoList<T>`) to keep an implementer from taking the long way around. |
+| Acceptance criteria | B- | Third bullet references "Scenario 2 of the design's test design section" but the design section has no numbered scenarios — it has a bulleted list. The test scenarios table numbers 1-7 does have a Scenario 2 about multi-type lookup, which is NOT the shared-wrapper sanity check. This will confuse the implementer. |
+| Risks section | A- | Names real risks (lock contention, test flakiness, reproducer sufficiency, audit scope creep, defensive list-cache hardening). The risk about flakiness suggests raising iteration count "or run tests in a loop with `[TestMethod]` helpers" — vague. |
+
+## Must-Fix Changes
+
+1. **[Must-fix] Design section, "Test design" bullets, reproducer semantics:** Specify exactly what each of the three stress tests resets between iterations. The corruption is persistent — once the dictionary is corrupted, every `set_Item` throws forever. If the test reuses one wrapper across all 640k calls, then on unmodified code the test reliably throws (proving corruption is reachable), and on fixed code it reliably passes (proving serialization works). But the value of Scenario 2's "reflection invoked at most once per type" check depends on a **fresh** wrapper. State explicitly: "Each test scenario constructs exactly one `PropertyInfoWrapper` instance shared by all threads for that test method, cold cache. Verification of the fix is: zero exceptions across all 640k calls AND for Scenario 2, the number of underlying `PropertyInfo.GetCustomAttribute<T>()` invocations equals 8 (one per type) — this requires a test-only subclass or a counter harness. The plan currently says 'reflection invoked at most once per type' as an expectation but does not show how to measure it."
+
+2. **[Must-fix] Acceptance Criteria, third bullet:** Reads "Shared-wrapper sanity test (Scenario 2 of the design's test design section)". There is no numbered Scenario 2 in the design's test design section — the numbered scenarios are in the Test Scenarios table, where Scenario 2 is the multi-type concurrent lookup, NOT the shared-wrapper sanity check. Fix: rename to "Shared-wrapper sanity test (Design section / Test design / 'Shared-wrapper sanity check' bullet)" and add it as its own numbered scenario (Scenario 8) in the Test Scenarios table so every AC bullet maps to a numbered scenario.
+
+3. **[Must-fix] Implementation Steps, Step 7 "Audit adjacent caches":** Specify the concrete Grep/search the implementer must run. Example list: (a) `private (static )?Dictionary<` in `src/Neatoo/` files where the enclosing type is registered Singleton (`AddNeatooServices.cs`) or referenced by a Singleton, (b) `private (static )?List<` used as a nullable lazy cache, (c) `private (static )?bool [a-zA-Z]+ = false;` flags paired with a populate method (the `isRegistered` pattern). Also: concretely list the files to check — `RuleManager`, `AttributeToRule`, `RuleMetadataCache` if any, `PropertyManager`, `ValidatePropertyManager`. An audit without a target list will be half-done.
+
+## Should-Fix Changes
+
+1. **[Should-fix] Business Rules:** Add a rule: "Rule 7: WHEN `GetCustomAttribute<TAttr>()` is called N times concurrently for the same `TAttr` against a cold-cache wrapper, THEN `PropertyInfo.GetCustomAttribute<TAttr>()` is invoked exactly once across all callers." This is what "exactly-once reflection" — the selling point of the lock-vs-ConcurrentDictionary choice — actually buys. Without it, the choice of `lock` over `ConcurrentDictionary.GetOrAdd` is not testable.
+
+2. **[Should-fix] Design section, "Code shape":** Add a one-line comment above the second `return this.customAttributes;` explaining that callers enumerate outside the lock but this is safe because the list is assigned once and never mutated after population. This is the kind of invariant that disappears in a future "small refactor" if undocumented.
+
+3. **[Should-fix] Test design bullets:** Specify that Scenario 2's `Random` instance must be seeded (e.g., `new Random(12345)`), and that Scenario 2 must NOT use a shared `Random` across threads (shared `Random` is itself not thread-safe and will throw — confusing failure mode). Use `ThreadLocal<Random>` seeded per-thread-id, or `Random.Shared` (which is thread-safe on .NET 6+) with a wrapper that derives per-thread seeds.
+
+4. **[Should-fix] Rule 2 wording:** "return references to `List<Attribute>` instances containing the complete attribute set" — "instances" is plural and contradicts Rule 5 ("same collection reference"). Rewrite: "return a reference to the same `List<Attribute>` instance containing the complete attribute set." Remove the plural.
+
+5. **[Should-fix] Implementation Steps, Step 1:** "Document the failure (paste the first failure output into the developer memory file during Step 5 code review)." Move this instruction to Step 4 or add a sub-step under Step 1 for "capture failure output to developer memory file" — waiting until Step 5 means the orchestrator may lose the evidence if the test is edited.
+
+6. **[Should-fix] Implementation Steps, Step 2:** The sanity test resolves "two `EntityProperty<P>` instances of the same type through the DI container" — but the actual sharing is via `PropertyInfoList<T>`, not `EntityProperty<P>`. Simpler and more direct: resolve `IPropertyInfoList<TSomeType>` twice from two separate scopes (or one scope, doesn't matter — it's Singleton), call `GetPropertyInfo("SomeProp")` on both, assert `AreSame` on the returned `IPropertyInfo` — and then cast to `PropertyInfoWrapper` and assert `AreSame` on that too. The current phrasing via `EntityProperty<P>` adds indirection and will require the implementer to set up more infrastructure than needed.
+
+## Nice-to-Have Changes
+
+1. **[Nice-to-have] Risks section, test flakiness bullet:** Replace "run tests in a loop with `[TestMethod]` helpers" with a concrete tactic: mark the test `[DataTestMethod]` with `[DataRow(1)]` through `[DataRow(5)]` so each test run executes the race 5 times and a single transient miss still fails the build.
+
+2. **[Nice-to-have] Test design bullets:** Note explicitly that the three concurrent scenarios should be marked `[TestCategory("Stress")]` or similar so they can be filtered out of fast-feedback dev loops if they turn out slow (10k x 64 = 640k reflection lookups is not free, even with a cached result).
+
+3. **[Nice-to-have] Risks section:** Add a risk: "If the `PropertyInfoWrapper` field initializer (`customAttribute = new()`) is ever moved to be set inside the lock on first call, the current design assumes the dictionary exists at construction time. Keep the field initializer where it is." Prevents a well-meaning "simplification" later that reintroduces a race (re-assigning the dictionary reference inside the lock).
+
+4. **[Nice-to-have] Overview:** State the blast radius more concretely — "until process restart, every entity construction of any type sharing the corrupted dictionary throws" is already in the todo; the plan elides this and a first-time reader may miss why this is a High priority patch-release bug.
+
+## What the Plan Got Right
+
+- **Correct root cause.** Sharing via static `PropertyInfoList<T>.PropertyInfos` on Singleton-lifetime registration. Confirmed by reading the code.
+- **Correct fix choice.** Single instance `lock` matches the existing `lockRegisteredProperties` pattern in `PropertyInfoList<T>`; idiomatic for this codebase.
+- **Rejected alternatives are named and dismissed with reasons** — this blocks future "why didn't you use `ConcurrentDictionary`" reviewers.
+- **Test-first ordering.** Step 1 requires the regression test to fail against unmodified code before the fix is written. This is the right discipline — without it, the tests prove nothing.
+- **Distinction between corrupting cache and merely redundant cache.** Correctly identifies that `customAttributes` (List) is not broken; the plan hardens it defensively with honest framing in the Risks section.
+- **Shared-wrapper sanity test is a good instinct.** Codifies the invariant that makes thread safety necessary; a future refactor making wrappers per-scope would fail it and signal the contract change.
+- **Business rules 3-6 are traced to existing tests** with file and line numbers — excellent traceability.
+- **Risks section names real risks**, not generic ones (lock contention, flakiness, reproducer sufficiency, audit scope creep, defensive hardening cost).
+- **No expansion into rewriting `PropertyInfoList<T>` or changing DI lifetimes.** Scope is tight.
+- **Release notes step is included** with specific instructions on what the entry must name (exception, stack site, contract affirmed).
+
+## Baseline Failure Output (pre-fix)
+
+**Date captured:** 2026-04-12
+**Command:** `dotnet test src/Neatoo.UnitTest/Neatoo.UnitTest.csproj --filter "FullyQualifiedName~PropertyInfoWrapperTests"`
+**Against:** `PropertyInfoWrapper.cs` with virtual seams added (`ReflectCustomAttribute`, `ReflectAllCustomAttributes`) but **no lock**.
+
+All 3 concurrent scenarios fail deterministically against the unfixed code:
+
+- **Scenario 1 (`GetCustomAttribute_ConcurrentSingleType_NoCorruption`):**
+  `Assert.AreEqual failed. Expected:<1>. Actual:<4>. Reflection for TestDescriptionAttribute must be invoked exactly once; observed 4.`
+  Interpretation: 4 threads all saw `ContainsKey==false` before any wrote, each invoked reflection. Cold-cache race confirmed.
+
+- **Scenario 2 (`GetCustomAttribute_ConcurrentMultiType_ReflectsOncePerType`):**
+  `Assert.AreEqual failed. Expected:<0>. Actual:<64>. First: InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.`
+  Interpretation: **Exact production stack trace reproduced.** 64 threads hit `Dictionary.set_Item` corruption; all subsequent calls also threw until the test aborted.
+
+- **Scenario 3 (`GetCustomAttributes_ConcurrentAccess_NoCorruption`):**
+  `Assert.AreEqual failed. Expected:<1>. Actual:<9>. All threads must observe the same cached list reference.`
+  Interpretation: 9 distinct `List<Attribute>` references returned — multiple threads racing through the null check, each building a fresh list, different consumers pinned different references.
+
+Scenarios 1 & 3 use reflection-invocation counts rather than hoping for rare `Dictionary` corruption — deterministic race indicators. Scenario 2 additionally reproduces the exact production exception.
+
+**Results summary:** `Failed: 3, Passed: 40, Skipped: 0, Total: 43` (Scenario 8 DI-sharing sanity test passes on current code as expected — the wrapper is shared by design; that's what makes thread-safety necessary.)
+
+## Adjacent Cache Audit
+
+**Date:** 2026-04-12
+**Scope:** `src/Neatoo/**/*.cs` (excluding tests, Neatoo.Analyzers, Neatoo.BaseGenerator).
+
+### Search A — unsynchronized lazy `Dictionary` / mutable dictionary fields
+
+| Location | Type | Enclosing lifetime | Verdict |
+|---|---|---|---|
+| `Internal/PropertyInfoWrapper.cs:32` `customAttribute` | `Dictionary<Type, Attribute?>` | Singleton-reachable (shared via `PropertyInfoList<T>.PropertyInfos` static) | **Fixed in this change** (instance `lock`) |
+| `Internal/ValidatePropertyManager.cs:99` `_createPropertyMethodPropertyType` | `static ConcurrentDictionary<Type, MethodInfo>` | Reachable from all scopes | **Safe** — already `ConcurrentDictionary` |
+| `Internal/AsyncTasks.cs:11` `_tasks` | `Dictionary<Guid, Task>` | Per-entity instance (Transient) | **Safe** — all mutations go through `lock (_lockObject)` on every read/write path; confirmed by reading `AddTask`, `SequenceCompleted`, and exception paths |
+| `Internal/PropertyInfoList.cs:12` `PropertyInfos` | `static IDictionary<string, IPropertyInfo>` | Singleton (per-T) | **Safe post-registration** — populated once under `lockRegisteredProperties`; read paths (`GetPropertyInfo`, `HasProperty`, `Properties`) call `RegisterProperties()` first which takes the lock, establishing a happens-before edge. After `isRegistered = true`, the dict is effectively immutable, so `TryGetValue` outside the lock is safe. Cross-referenced: `docs/todos/remove-inconsistent-locks.md` discusses inconsistent locking but not this specific path — still safe by the happens-before argument |
+| `Rules/RuleManager.cs:374` `Rules` | `Dictionary<uint, IRule>` | Per-entity (Transient) | **Safe** — not shared across threads at framework level; per-entity state, caller is responsible for threading |
+
+### Search B — unsynchronized lazy nullable `List`/`IEnumerable` caches
+
+| Location | Type | Enclosing lifetime | Verdict |
+|---|---|---|---|
+| `Internal/PropertyInfoWrapper.cs:62` `customAttributes` | `List<Attribute>?` | Singleton-reachable | **Fixed in this change** (defensive hardening; did not corrupt in production but produced redundant reflection under contention) |
+
+No other `private (static )?List<.*>?` lazy-populate patterns found in Neatoo core.
+
+### Search C — `isRegistered`-style one-time-init flags
+
+| Location | Flag | Lock-guarded? | Verdict |
+|---|---|---|---|
+| `Internal/PropertyInfoList.cs:13` `isRegistered` | `private static bool` | Yes — reads + write inside `lock (lockRegisteredProperties)` | **Safe** |
+| `EntityListBase.cs:51` `_cachedChildrenModified`, `ValidateListBase.cs:60` `_cachedIsBusy`, `Internal/ValidateProperty.cs:122` `_isReadOnly` | `private bool` | Per-instance Transient state, not shared across threads at framework level | **Safe in practice** — not singleton-reachable, not a one-time-init pattern |
+
+### Other singleton candidates inspected
+
+- `Rules/Rules/AttributeToRule.cs` (registered `AddSingleton<IAttributeToRule, AttributeToRule>`): **stateless** — no fields; `GetRule` is a pure switch over the attribute type, `CreateTriggerProperty` creates a fresh lambda each call. Safe.
+- `Internal/PropertyManager*.cs`, `Internal/EntityPropertyManager*.cs`, `Internal/ValidatePropertyManager.cs`: the factories are Transient-resolved via `CreateValidatePropertyManager` / `CreateEntityPropertyManager` delegates; each entity gets its own manager. `_createPropertyMethodPropertyType` (the only singleton-reachable cache) is `ConcurrentDictionary`. Safe.
+
+### Conclusion
+
+**No additional fixes required.** The only unsynchronized singleton-reachable lazy caches in Neatoo core were the two `PropertyInfoWrapper` fields addressed by this change. `PropertyInfoList<T>` was architecturally close to the same mistake but was already lock-guarded on registration and has correct happens-before on the read path. `AsyncTasks` uses explicit locking on every path. No new todos filed.
+
+## Verdict
+
+To reach Grade A: fix the three must-fixes (reproducer semantics including fresh-wrapper rule and reflection-count measurement, the broken Scenario 2 reference in acceptance criteria, and the vague audit step), then address the should-fix items around Rule 2's contradictory wording, the missing "exactly-once reflection" rule, and the `Random` seeding discipline. None of these require architectural rethinking — they are specification tightening. The core approach (instance `lock` over both caches, test-first, audit adjacent) is sound and should not be changed.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Neatoo 0.28.0** (2026-04-08)
+**Neatoo 0.28.1** (2026-04-12)
 
 ---
 
@@ -12,6 +12,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date | Type | Summary |
 |---------|------|------|---------|
+| [0.28.1](v0.28.1.md) | 2026-04-12 | Bug Fix | `PropertyInfoWrapper` attribute caches thread-safe; fixes shared-wrapper Dictionary corruption under concurrent load |
 | [0.28.0](v0.28.0.md) | 2026-04-08 | Feature | `Logger` is now `ILogger<T>` for consumer logging |
 | [0.27.0](v0.27.0.md) | 2026-04-06 | Feature | Field-level authorization via `MarkReadOnly()` |
 | [0.26.1](v0.26.1.md) | 2026-04-04 | Bug Fix | Hash-based rule IDs fix inheritance collision |

--- a/docs/release-notes/v0.28.1.md
+++ b/docs/release-notes/v0.28.1.md
@@ -1,0 +1,52 @@
+# Neatoo 0.28.1
+
+**Release Date:** 2026-04-12
+**Type:** Patch
+**Breaking Changes:** No
+
+---
+
+## Summary
+
+Fixes a thread-safety bug in `PropertyInfoWrapper` that corrupted internal caches under concurrent server load and produced `System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state.` from every subsequent entity construction until process restart.
+
+---
+
+## What Changed
+
+### `PropertyInfoWrapper` attribute caches are now thread-safe
+
+`PropertyInfoWrapper` instances are shared across all threads and DI scopes in a running process (via `PropertyInfoList<T>.PropertyInfos`, a static dictionary on a Singleton-lifetime list type). The wrapper's two lazy attribute caches — a `Dictionary<Type, Attribute?>` and a `List<Attribute>?` — were populated without synchronization. Under concurrent entity construction, races on the non-concurrent `Dictionary` corrupted its internal state and produced `InvalidOperationException` on every subsequent `set_Item` across all threads until the process was restarted.
+
+Both caches are now serialized behind a single instance-level lock. Reflection is invoked at most once per attribute type (and at most once for the all-attributes list) — the lock is only contended during cache warm-up.
+
+### Observable contract affirmed
+
+- `GetCustomAttribute<T>()` is safe to call concurrently on a shared wrapper; all callers observe the same cached attribute instance, reflection is invoked exactly once per attribute type.
+- `GetCustomAttributes()` is safe to call concurrently on a shared wrapper; all callers observe the same cached list reference, reflection is invoked exactly once.
+
+### Stack site
+
+The original failure surfaced at:
+
+```
+System.InvalidOperationException
+   at System.Collections.Generic.Dictionary`2.set_Item(TKey, TValue)
+   at Neatoo.Internal.PropertyInfoWrapper.GetCustomAttribute[T]()
+   at Neatoo.Internal.EntityProperty`1..ctor(IPropertyInfo propertyInfo)
+   at Neatoo.Internal.DefaultFactory.CreateEntityProperty[P](IPropertyInfo propertyInfo)
+   at Neatoo.Internal.EntityPropertyFactory`1.Create[TProperty](TOwner owner, String propertyName)
+```
+
+---
+
+## Migration
+
+No action required. Patch release, no public API changes.
+
+---
+
+## Related
+
+- [v0.28.0 - ValidateBase Logger is ILogger&lt;T&gt;](v0.28.0.md)
+- [Completed todo](../todos/completed/propertyinfowrapper-thread-safety.md)

--- a/docs/todos/propertyinfowrapper-thread-safety.md
+++ b/docs/todos/propertyinfowrapper-thread-safety.md
@@ -1,0 +1,157 @@
+# PropertyInfoWrapper Thread Safety — Concurrent Dictionary Corruption
+
+**Status:** In Progress
+**Priority:** High
+**Created:** 2026-04-12
+**Last Updated:** 2026-04-12
+
+---
+
+## Problem
+
+Under concurrent server load, entity construction fails with:
+
+```
+System.InvalidOperationException: 'Operations that change non-concurrent collections must have
+exclusive access. A concurrent update was performed on this collection and corrupted its state.
+The collection's state is no longer correct.'
+   at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue value)
+   at Neatoo.Internal.PropertyInfoWrapper.GetCustomAttribute[T]()
+   at Neatoo.Internal.EntityProperty`1..ctor(IPropertyInfo propertyInfo)
+   at Neatoo.Internal.DefaultFactory.CreateEntityProperty[P](IPropertyInfo propertyInfo)
+   at Neatoo.Internal.EntityPropertyFactory`1.Create[TProperty](TOwner owner, String propertyName)
+   at zTreatment.DomainModels.Visit.SymptomsAssessment.InitializePropertyBackingFields(...)
+   at Neatoo.ValidateBase`1..ctor(IValidateBaseServices`1 services)
+   at Neatoo.EntityBase`1..ctor(IEntityBaseServices`1 services)
+```
+
+Once the dictionary corrupts, the error recurs for every subsequent entity construction of any type whose wrapper shares the corrupted dictionary. The process stays broken until restart.
+
+Reported from `zTreatment` production workload while loading symptoms for consultation 4964415.
+
+---
+
+## Analysis (Neatoo Team)
+
+### Why the same wrapper is shared across threads
+
+`PropertyInfoList<T>` (`src/Neatoo/Internal/PropertyInfoList.cs`) holds its wrappers in a **`static` field**:
+
+```csharp
+protected static IDictionary<string, IPropertyInfo> PropertyInfos { get; } = new Dictionary<string, IPropertyInfo>();
+```
+
+The list itself is registered as **singleton** in DI (`AddNeatooServices.cs:63`). `RegisterProperties()` populates `PropertyInfos` once per closed generic `T` inside a `lock`, and the wrappers are reused from that static dictionary forever.
+
+The `CreatePropertyInfoWrapper` delegate is transient, but that is irrelevant — it is only invoked once per property inside the `RegisterProperties` lock. After that, every `EntityProperty<P>` constructor, on any thread, in any DI scope, for a given property of `T`, receives the **same** `PropertyInfoWrapper` instance.
+
+### What breaks
+
+`PropertyInfoWrapper.GetCustomAttribute<T>()` (`src/Neatoo/Internal/PropertyInfoWrapper.cs:23`):
+
+```csharp
+private Dictionary<Type, Attribute?> customAttribute = new();
+
+public T? GetCustomAttribute<T>() where T : Attribute
+{
+    if(!this.customAttribute.ContainsKey(typeof(T)))
+    {
+        this.customAttribute[typeof(T)] = this.PropertyInfo.GetCustomAttribute<T>();
+    }
+    return (T?) this.customAttribute[typeof(T)];
+}
+```
+
+Concurrent entity constructions call this on the same wrapper instance. The non-atomic `ContainsKey` -> `set_Item` sequence on a plain `Dictionary<,>` permits two threads to both pass `ContainsKey` and both enter `set_Item`. `Dictionary<,>` detects concurrent structural mutation via its internal `_version` field and throws `InvalidOperationException`. Once the internal buckets and version counters are out of sync, every subsequent `set_Item` — from any thread, for any key — throws.
+
+### Which caches are actually broken
+
+`PropertyInfoWrapper` has two lazy caches. Only one causes corruption:
+
+| Field | Type | Impact under contention |
+|---|---|---|
+| `customAttribute` | `Dictionary<Type, Attribute?>` | **Corrupts** — races on `set_Item` trigger `_version` mismatch |
+| `customAttributes` | `List<Attribute>?` (nullable reference) | No corruption — reference assignment is atomic; worst case is redundant reflection |
+
+The production stack trace implicates `GetCustomAttribute<T>()` specifically. `GetCustomAttributes()` is not broken but is adjacent enough to warrant consideration during the fix design.
+
+### Why unit tests never caught this
+
+- Existing `PropertyInfoWrapperTests` construct wrappers locally in each test — no sharing across threads
+- `IntegrationTestBase` runs tests serially
+- Dev-loop workloads (console app, local Blazor WASM) never race
+- The race window is small; it takes sustained concurrent server traffic to trigger
+
+---
+
+## Requirements Review
+
+**Verdict:** Pending
+**Reviewed:**
+**Summary:**
+
+Business requirements source for this todo: `src/Design/Design.Domain/PropertySystem/` and related.
+
+---
+
+## Plans
+
+- [PropertyInfoWrapper Thread Safety — Plan](../plans/propertyinfowrapper-thread-safety.md)
+
+---
+
+## Tasks
+
+- [ ] Confirm thread-safety contract in `src/Design/Design.Domain/` — is thread-safe concurrent construction of entities a documented design requirement?
+- [ ] Write a concurrent regression test that reproduces `Dictionary` corruption on a shared `PropertyInfoWrapper.GetCustomAttribute<T>()`. Test must fail deterministically (or near-deterministically) against current code, covering both cold-cache and post-corruption failure modes.
+- [ ] Design the fix in the plan (no approach predetermined; evaluate options against the design project thread-safety contract and weigh against existing patterns in adjacent code)
+- [ ] Implement fix in `PropertyInfoWrapper`
+- [ ] Decide whether `customAttributes` (List cache) also gets hardened in the same change, or deferred — document the decision in the plan
+- [ ] Concurrent regression test passes; run stress (1000+ iterations) to confirm stability
+- [ ] Audit adjacent caches for the same shape:
+  - `PropertyInfoList<T>` static state (`PropertyInfos` dictionary, `isRegistered` flag — these already sit behind `lockRegisteredProperties`, but re-verify read paths)
+  - Other Neatoo internal caches with `private Dictionary<` / `private List<` lazily populated fields
+  - Cross-reference `docs/todos/remove-inconsistent-locks.md`
+- [ ] Full `dotnet build src/Neatoo.sln` and `dotnet test src/Neatoo.sln` green
+- [ ] Release notes entry added (patch version — bug fix)
+
+---
+
+## Progress Log
+
+### 2026-04-12
+- Bug reported from zTreatment production workload (symptoms load for consultation 4964415)
+- Outside team (zTreatment) drafted the initial todo with their own analysis and fix sketch
+- Neatoo team re-analyzed: confirmed the corruption is real; corrected the root-cause explanation (sharing happens via `PropertyInfoList<T>.PropertyInfos` static field, not via the transient `CreatePropertyInfoWrapper` delegate)
+- Scoped the broken surface: `customAttribute` dictionary is the only corrupting cache; `customAttributes` list is redundant-under-contention but not broken
+- Rewrote task list; deferred fix design to the plan
+- Implementation complete (per user request to skip to implementation):
+  - Added virtual reflection seams (`ReflectCustomAttribute`, `ReflectAllCustomAttributes`) + instance `cacheLock` guarding both caches in `PropertyInfoWrapper.cs`
+  - Added Thread Safety Tests region with Scenarios 1, 2, 3, 8 in `PropertyInfoWrapperTests.cs`
+  - Verified tests fail deterministically against unfixed code (Scenario 1: 4x reflection for single type; Scenario 2: exact production `InvalidOperationException` reproduced; Scenario 3: 9 distinct list refs). Baseline captured in developer memory file
+  - After fix: all 3 concurrent scenarios pass across 3 consecutive runs; full suite green (1793 Neatoo.UnitTest + 42 BaseGenerator + 254 Samples + 55 Person.DomainModel.Tests, 0 failures)
+  - Adjacent-cache audit complete (developer memory file) — no additional fixes needed
+  - Version bumped to 0.28.1; release notes added
+- Next: Step 5 (developer code review) if running full workflow
+
+---
+
+## Completion Verification
+
+Before marking this todo as Complete, verify:
+
+- [ ] All builds pass (`dotnet build src/Neatoo.sln`)
+- [ ] All tests pass (`dotnet test src/Neatoo.sln`)
+- [ ] New concurrent regression test added and passing under stress
+- [ ] Adjacent-cache audit completed with findings documented (fixes or new todos)
+- [ ] Release notes entry merged
+
+**Verification results:**
+- Build: Pending
+- Tests: Pending
+
+---
+
+## Results / Conclusions
+
+[Pending]

--- a/src/Neatoo.UnitTest/ClientServerContainer.cs
+++ b/src/Neatoo.UnitTest/ClientServerContainer.cs
@@ -55,7 +55,7 @@ namespace Neatoo.UnitTest
             return result;
         }
 
-        public async Task ForDelegateEvent(Type delegateType, object?[]? parameters)
+        public async Task ForDelegateEvent(Type delegateType, object?[]? parameters, CancellationToken cancellationToken = default)
         {
             // For events, we simulate the fire-and-forget pattern
             // The server handles in a new scope, but we await acknowledgment
@@ -67,7 +67,7 @@ namespace Neatoo.UnitTest
             // Use the Server's container - fire and forget semantics (no return value needed)
             await serviceProvider.GetRequiredService<ServerServiceProvider>()
                                  .serverProvider
-                                 .GetRequiredService<HandleRemoteDelegateRequest>()(remoteRequestOnServer, default);
+                                 .GetRequiredService<HandleRemoteDelegateRequest>()(remoteRequestOnServer, cancellationToken);
         }
     }
 

--- a/src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs
+++ b/src/Neatoo.UnitTest/Unit/Core/PropertyInfoWrapperTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Concurrent;
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neatoo.Internal;
+using Neatoo.RemoteFactory;
 
 namespace Neatoo.UnitTest.Unit.Core;
 
@@ -47,6 +50,17 @@ public class TestTagAttribute : Attribute
         Tag = tag;
     }
 }
+
+// Eight single-allowed attribute types used by the concurrent multi-type stress test (Scenario 2).
+// TestAttr1..TestAttr4 are applied to ThreadSafetyTestClass.MixedProperty; TestAttr5..TestAttr8 are not.
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr1Attribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr2Attribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr3Attribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr4Attribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr5Attribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr6Attribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr7Attribute : Attribute { }
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)] public class TestAttr8Attribute : Attribute { }
 
 #endregion
 
@@ -104,6 +118,19 @@ public class AccessModifierTestClass
     public string PublicGetPrivateSet { get; private set; } = string.Empty;
 
     public string InitOnlyProperty { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// POCO used by thread-safety tests. MixedProperty carries TestAttr1..TestAttr4 but not TestAttr5..TestAttr8.
+/// </summary>
+public class ThreadSafetyTestClass
+{
+    [TestAttr1]
+    [TestAttr2]
+    [TestAttr3]
+    [TestAttr4]
+    [TestDescription("Thread safety test property")]
+    public string MixedProperty { get; set; } = string.Empty;
 }
 
 /// <summary>
@@ -679,6 +706,230 @@ public class PropertyInfoWrapperTests
 
         // Act & Assert
         Assert.AreEqual(typeof(IEnumerable<string>), wrapper.Type);
+    }
+
+    #endregion
+
+    #region Thread Safety Tests
+
+    // Test-only subclass that counts reflection invocations. Used to verify the
+    // "exactly once per type" and "exactly once for all-attrs" guarantees that the
+    // lock buys over ConcurrentDictionary.GetOrAdd. Detecting >1 invocations is a
+    // deterministic race indicator — the InvalidOperationException from Dictionary
+    // corruption is a rarer downstream consequence of the same root cause, so we
+    // assert on the more reliable signal.
+    private class CountingPropertyInfoWrapper : PropertyInfoWrapper
+    {
+        public ConcurrentDictionary<Type, int> ReflectCount { get; } = new();
+        public int ReflectAllCount;
+
+        public CountingPropertyInfoWrapper(PropertyInfo propertyInfo) : base(propertyInfo) { }
+
+        protected override Attribute? ReflectCustomAttribute(Type attrType)
+        {
+            ReflectCount.AddOrUpdate(attrType, 1, (_, v) => v + 1);
+            return base.ReflectCustomAttribute(attrType);
+        }
+
+        protected override List<Attribute> ReflectAllCustomAttributes()
+        {
+            Interlocked.Increment(ref ReflectAllCount);
+            return base.ReflectAllCustomAttributes();
+        }
+    }
+
+    private const int StressThreadCount = 64;
+    private const int StressIterationsPerThread = 10_000;
+
+    /// <summary>
+    /// Scenario 1: N threads repeatedly call GetCustomAttribute{T}() on the same wrapper for the same T.
+    /// Against unmodified PropertyInfoWrapper, the internal Dictionary corrupts within a few hundred
+    /// iterations and throws InvalidOperationException. Against the locked version, all calls succeed
+    /// and return the same attribute instance.
+    /// </summary>
+    [TestMethod]
+    public void GetCustomAttribute_ConcurrentSingleType_NoCorruption()
+    {
+        var propertyInfo = typeof(ThreadSafetyTestClass).GetProperty(nameof(ThreadSafetyTestClass.MixedProperty))!;
+        var wrapper = new CountingPropertyInfoWrapper(propertyInfo);
+        var gate = new ManualResetEventSlim(false);
+        var exceptions = new ConcurrentBag<Exception>();
+        var observedInstances = new ConcurrentBag<TestDescriptionAttribute?>();
+
+        var tasks = Enumerable.Range(0, StressThreadCount).Select(_ => Task.Run(() =>
+        {
+            gate.Wait();
+            for (int i = 0; i < StressIterationsPerThread; i++)
+            {
+                try
+                {
+                    var attr = wrapper.GetCustomAttribute<TestDescriptionAttribute>();
+                    if (i == StressIterationsPerThread - 1)
+                    {
+                        observedInstances.Add(attr);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                    return;
+                }
+            }
+        })).ToArray();
+
+        gate.Set();
+        Task.WaitAll(tasks);
+
+        Assert.AreEqual(0, exceptions.Count,
+            $"Expected zero exceptions across {StressThreadCount * StressIterationsPerThread} concurrent calls. " +
+            $"First exception: {exceptions.FirstOrDefault()?.GetType().Name}: {exceptions.FirstOrDefault()?.Message}");
+
+        Assert.IsTrue(wrapper.ReflectCount.TryGetValue(typeof(TestDescriptionAttribute), out var count),
+            "TestDescriptionAttribute must have been queried.");
+        Assert.AreEqual(1, count,
+            $"Reflection for TestDescriptionAttribute must be invoked exactly once; observed {count}. " +
+            "More than one invocation indicates a cold-cache race between threads.");
+
+        var distinctInstances = observedInstances.Where(a => a != null).Distinct().ToList();
+        Assert.AreEqual(1, distinctInstances.Count, "All threads must observe the same cached attribute instance.");
+    }
+
+    /// <summary>
+    /// Scenario 2: N threads concurrently lookup randomly-chosen TAttr from 8 types (4 present, 4 absent).
+    /// Verifies zero exceptions AND that reflection is invoked exactly once per attribute type —
+    /// the core property that the lock provides over ConcurrentDictionary.GetOrAdd.
+    /// </summary>
+    [TestMethod]
+    public void GetCustomAttribute_ConcurrentMultiType_ReflectsOncePerType()
+    {
+        var propertyInfo = typeof(ThreadSafetyTestClass).GetProperty(nameof(ThreadSafetyTestClass.MixedProperty))!;
+        var wrapper = new CountingPropertyInfoWrapper(propertyInfo);
+
+        var lookupActions = new Action[]
+        {
+            () => wrapper.GetCustomAttribute<TestAttr1Attribute>(),
+            () => wrapper.GetCustomAttribute<TestAttr2Attribute>(),
+            () => wrapper.GetCustomAttribute<TestAttr3Attribute>(),
+            () => wrapper.GetCustomAttribute<TestAttr4Attribute>(),
+            () => wrapper.GetCustomAttribute<TestAttr5Attribute>(),
+            () => wrapper.GetCustomAttribute<TestAttr6Attribute>(),
+            () => wrapper.GetCustomAttribute<TestAttr7Attribute>(),
+            () => wrapper.GetCustomAttribute<TestAttr8Attribute>(),
+        };
+
+        var gate = new ManualResetEventSlim(false);
+        var exceptions = new ConcurrentBag<Exception>();
+
+        var tasks = Enumerable.Range(0, StressThreadCount).Select(threadIndex => Task.Run(() =>
+        {
+            // Per-thread deterministic seeding. System.Random is not thread-safe; sharing it
+            // across threads would itself throw and produce a confusing failure.
+            var rng = new Random(12345 + threadIndex);
+            gate.Wait();
+            for (int i = 0; i < StressIterationsPerThread; i++)
+            {
+                try
+                {
+                    lookupActions[rng.Next(lookupActions.Length)]();
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                    return;
+                }
+            }
+        })).ToArray();
+
+        gate.Set();
+        Task.WaitAll(tasks);
+
+        Assert.AreEqual(0, exceptions.Count,
+            $"Expected zero exceptions. First: {exceptions.FirstOrDefault()?.GetType().Name}: {exceptions.FirstOrDefault()?.Message}");
+
+        Assert.AreEqual(8, wrapper.ReflectCount.Count, "All 8 attribute types must have been queried at least once.");
+        foreach (var entry in wrapper.ReflectCount)
+        {
+            Assert.AreEqual(1, entry.Value,
+                $"Reflection for {entry.Key.Name} must be invoked exactly once; observed {entry.Value}.");
+        }
+    }
+
+    /// <summary>
+    /// Scenario 3: N threads concurrently call GetCustomAttributes() on the same wrapper.
+    /// Verifies zero exceptions and that all callers observe the same cached List reference.
+    /// </summary>
+    [TestMethod]
+    public void GetCustomAttributes_ConcurrentAccess_NoCorruption()
+    {
+        var propertyInfo = typeof(ThreadSafetyTestClass).GetProperty(nameof(ThreadSafetyTestClass.MixedProperty))!;
+        var wrapper = new CountingPropertyInfoWrapper(propertyInfo);
+        var gate = new ManualResetEventSlim(false);
+        var exceptions = new ConcurrentBag<Exception>();
+        var observedReferences = new ConcurrentBag<IEnumerable<Attribute>>();
+
+        var tasks = Enumerable.Range(0, StressThreadCount).Select(_ => Task.Run(() =>
+        {
+            gate.Wait();
+            for (int i = 0; i < StressIterationsPerThread; i++)
+            {
+                try
+                {
+                    var attrs = wrapper.GetCustomAttributes();
+                    if (i == StressIterationsPerThread - 1)
+                    {
+                        observedReferences.Add(attrs);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                    return;
+                }
+            }
+        })).ToArray();
+
+        gate.Set();
+        Task.WaitAll(tasks);
+
+        Assert.AreEqual(0, exceptions.Count,
+            $"Expected zero exceptions. First: {exceptions.FirstOrDefault()?.GetType().Name}: {exceptions.FirstOrDefault()?.Message}");
+
+        var distinctRefs = observedReferences.Distinct(ReferenceEqualityComparer.Instance).ToList();
+        Assert.AreEqual(1, distinctRefs.Count, "All threads must observe the same cached list reference.");
+
+        Assert.AreEqual(1, wrapper.ReflectAllCount,
+            $"ReflectAllCustomAttributes must be invoked exactly once; observed {wrapper.ReflectAllCount}.");
+
+        var baseline = wrapper.GetCustomAttributes().ToList();
+        Assert.AreEqual(5, baseline.Count, "Expected 5 attributes on MixedProperty (TestAttr1..4 + TestDescription).");
+    }
+
+    /// <summary>
+    /// Scenario 8: Shared-wrapper sanity. Resolving IPropertyInfoList{T} twice from DI must yield
+    /// the same list instance, and calling GetPropertyInfo on each must return the same wrapper.
+    /// Codifies the invariant that makes thread-safety necessary. A future refactor that makes
+    /// wrappers per-scope or per-instance would fail this test and flag the contract change.
+    /// </summary>
+    [TestMethod]
+    public void PropertyInfoList_ResolvedTwiceFromDI_SharesSameWrappers()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(IPropertyInfoList<>), typeof(PropertyInfoList<>));
+        services.AddTransient<CreatePropertyInfoWrapper>(_ => pi => new PropertyInfoWrapper(pi));
+        using var sp = services.BuildServiceProvider();
+
+        var list1 = sp.GetRequiredService<IPropertyInfoList<Neatoo.UnitTest.Unit.Rules.TestValidateObject>>();
+        var list2 = sp.GetRequiredService<IPropertyInfoList<Neatoo.UnitTest.Unit.Rules.TestValidateObject>>();
+
+        Assert.AreSame(list1, list2, "Singleton registration must yield the same PropertyInfoList instance.");
+
+        var info1 = list1.GetPropertyInfo(nameof(Neatoo.UnitTest.Unit.Rules.TestValidateObject.StringProperty));
+        var info2 = list2.GetPropertyInfo(nameof(Neatoo.UnitTest.Unit.Rules.TestValidateObject.StringProperty));
+
+        Assert.IsNotNull(info1);
+        Assert.IsNotNull(info2);
+        Assert.AreSame(info1, info2, "PropertyInfoList<T> must return the same IPropertyInfo on repeat resolutions.");
+        Assert.IsInstanceOfType(info1, typeof(PropertyInfoWrapper));
     }
 
     #endregion

--- a/src/Neatoo/Internal/PropertyInfoWrapper.cs
+++ b/src/Neatoo/Internal/PropertyInfoWrapper.cs
@@ -18,25 +18,51 @@ public class PropertyInfoWrapper : IPropertyInfo
     public string Key => this.Name;
     public bool IsPrivateSetter { get; }
 
+    // Serializes access to customAttribute and customAttributes. Wrappers are shared across
+    // all threads and DI scopes (PropertyInfoList<T>.PropertyInfos is static), so concurrent
+    // cold-cache population was corrupting the non-thread-safe Dictionary. Instance lock —
+    // different wrappers do not contend. Critical section is a dictionary lookup or reference
+    // read once populated, so contention cost is negligible post-warm-up.
+    private readonly object cacheLock = new object();
+
     private Dictionary<Type, Attribute?> customAttribute = new();
+
+    // Virtual seams for test harnesses to count reflection invocations. Production path
+    // delegates to System.Reflection; tests can override to track invocation counts.
+    protected virtual Attribute? ReflectCustomAttribute(Type attrType)
+        => this.PropertyInfo.GetCustomAttribute(attrType);
+
+    protected virtual List<Attribute> ReflectAllCustomAttributes()
+        => this.PropertyInfo.GetCustomAttributes().ToList();
 
     public T? GetCustomAttribute<T>() where T : Attribute
     {
-        if(!this.customAttribute.ContainsKey(typeof(T)))
+        lock (this.cacheLock)
         {
-            this.customAttribute[typeof(T)] = this.PropertyInfo.GetCustomAttribute<T>();
-        }
+            if(!this.customAttribute.ContainsKey(typeof(T)))
+            {
+                this.customAttribute[typeof(T)] = ReflectCustomAttribute(typeof(T));
+            }
 
-        return (T?) this.customAttribute[typeof(T)];
+            return (T?) this.customAttribute[typeof(T)];
+        }
     }
 
     private List<Attribute>? customAttributes;
 
     public IEnumerable<Attribute> GetCustomAttributes(){
-        if(this.customAttributes == null)
+        lock (this.cacheLock)
         {
-            this.customAttributes = this.PropertyInfo.GetCustomAttributes().ToList();
+            if(this.customAttributes == null)
+            {
+                this.customAttributes = ReflectAllCustomAttributes();
+            }
+            // Safe to return the reference from inside the lock: the list is assigned exactly
+            // once on first population and never mutated afterward. Callers enumerate outside
+            // the lock, but since the reference is stable and contents are immutable
+            // post-assignment, no torn reads are possible. Any future change that reassigns
+            // this field outside the lock (e.g., a "clear cache" API) reintroduces the race.
+            return this.customAttributes;
         }
-        return this.customAttributes;
     }
 }


### PR DESCRIPTION
## Summary

- **Thread-safety fix**: `PropertyInfoWrapper` attribute caches are now serialized behind an instance `cacheLock`. Wrappers are shared process-wide via `PropertyInfoList<T>.PropertyInfos` (static field on a Singleton), so concurrent entity construction was racing on the unsynchronized `Dictionary<Type, Attribute?>` and producing `InvalidOperationException` from `Dictionary.set_Item` that persisted until process restart. Reported from zTreatment production.
- **Version bump**: 0.28.0 → 0.28.1 (patch); release notes added at `docs/release-notes/v0.28.1.md`.
- **RemoteFactory upgrade**: 0.29.0 → 1.1.0. One breaking-change fixup: `IMakeRemoteDelegateRequest.ForDelegateEvent` gained a `CancellationToken` parameter; updated the test double at `ClientServerContainer.cs`.

## How the fix catches the bug

The concurrent regression tests fail deterministically against the unfixed code:

- **Scenario 1** (single-type cold-cache race): reflection observed 4× instead of 1×.
- **Scenario 2** (multi-type stress): reproduces the exact production `InvalidOperationException` stack.
- **Scenario 3** (List cache race): 9 distinct list references across threads.
- **Scenario 8** (DI sharing sanity): codifies that wrappers are shared by design — a future refactor making them per-scope would fail this test and flag the contract change.

After the fix, all scenarios pass across 3 consecutive stability runs.

## Test plan

- [x] `dotnet build src/Neatoo.sln` — 0 errors
- [x] `dotnet test src/Neatoo.sln` — Neatoo.UnitTest: 1793 passed / 2 skipped; Samples: 254/254; Person.DomainModel.Tests: 55/55; Neatoo.BaseGenerator.Tests: 42/42
- [x] Concurrent regression tests fail pre-fix with correct diagnostics (baseline captured in `docs/plans/propertyinfowrapper-thread-safety.memory/developer.md`)
- [x] Concurrent regression tests pass post-fix across 3 consecutive runs
- [x] Adjacent-cache audit — no further fixes needed (see developer memory file)
- [ ] Smoke test in zTreatment against 0.28.1 once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)