### PR TITLE
feat: MudNeatoo Sizing/MaxLines + NumericField null-clamp fix (v0.29.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>0.28.1</Version>
+		<Version>0.29.0</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Neatoo 0.28.1** (2026-04-12)
+**Neatoo 0.29.0** (2026-04-13)
 
 ---
 
@@ -12,6 +12,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date | Type | Summary |
 |---------|------|------|---------|
+| [0.29.0](v0.29.0.md) | 2026-04-13 | Feature + Fix | MudNeatooTextField `Sizing`/`MaxLines`; MudNeatooNumericField no longer clamps to 0 when Min/Max/Step unset |
 | [0.28.1](v0.28.1.md) | 2026-04-12 | Bug Fix | `PropertyInfoWrapper` attribute caches thread-safe; fixes shared-wrapper Dictionary corruption under concurrent load |
 | [0.28.0](v0.28.0.md) | 2026-04-08 | Feature | `Logger` is now `ILogger<T>` for consumer logging |
 | [0.27.0](v0.27.0.md) | 2026-04-06 | Feature | Field-level authorization via `MarkReadOnly()` |

--- a/docs/release-notes/v0.29.0.md
+++ b/docs/release-notes/v0.29.0.md
@@ -1,0 +1,50 @@
+# Neatoo 0.29.0
+
+**Release Date:** 2026-04-13
+**Type:** Minor
+**Breaking Changes:** No
+
+---
+
+## Summary
+
+MudNeatoo additions and fixes:
+
+- `MudNeatooTextField` now exposes `Sizing` and `MaxLines` for MudBlazor 9's auto-growing textareas.
+- `MudNeatooNumericField` no longer silently clamps values to `0` when `Min`/`Max`/`Step` are left unset.
+
+---
+
+## What Changed
+
+### `MudNeatooTextField`: `Sizing` and `MaxLines` parameters
+
+Two new parameters passed through to `MudTextField`:
+
+- `Sizing` (`InputSizing`, default `Fixed`) — set to `InputSizing.Auto` for a textarea that grows with its content. Requires `Lines > 1`.
+- `MaxLines` (`int`, default `0`) — upper bound on auto-grow. `0` means unlimited.
+
+Mirrors MudBlazor 9's API exactly; no renaming.
+
+```razor
+<MudNeatooTextField T="string"
+                    EntityProperty="Entity.NotesProperty"
+                    Lines="3"
+                    Sizing="InputSizing.Auto"
+                    MaxLines="10" />
+```
+
+### `MudNeatooNumericField`: `Min`/`Max`/`Step` no longer clamp to zero when unset
+
+Previously, `Min`/`Max`/`Step` were typed `T?` and forwarded to `MudNumericField<T>` even when null. Blazor's attribute binding converted `null` to `default(T)` — for `int`, `Max = 0` — which MudBlazor treats as a real upper bound and silently clamps every value to `0`. The field appeared to reset to zero on any user interaction.
+
+The wrapper now splats `Min`/`Max`/`Step` into `MudNumericField` only when the caller explicitly set them. Unset values are omitted entirely, letting MudBlazor apply its own defaults (`T.MinValue`, `T.MaxValue`, `1`) via its internal converter dispatcher. Works for both non-nullable (`int`) and nullable (`int?`) type parameters.
+
+No API change — existing consumers that never set these parameters will just start behaving correctly.
+
+---
+
+## Related
+
+- [v0.28.1 - PropertyInfoWrapper attribute caches thread-safe](v0.28.1.md)
+- [Completed todo](../todos/completed/mudneatoo-numeric-field-null-min-max.md)

--- a/docs/todos/completed/mudneatoo-numeric-field-null-min-max.md
+++ b/docs/todos/completed/mudneatoo-numeric-field-null-min-max.md
@@ -1,0 +1,36 @@
+# MudNeatooNumericField: Nullable Min/Max/Step Passed as default(T) to MudBlazor
+
+- **Status:** Completed
+- **Priority:** High
+- **Created:** 2026-04-06
+- **Completed:** 2026-04-13 (v0.29.0)
+
+## Problem
+
+`MudNeatooNumericField<T>` declares `Min`, `Max`, and `Step` as `T?` (nullable), defaulting to `null`. These are passed directly to MudBlazor's `MudNumericField<T>` which expects `T` (non-nullable). MudBlazor's own defaults are `T.MinValue` / `T.MaxValue` via `IMinMaxValue<T>`.
+
+When the caller does not set `Min`/`Max`/`Step`, Blazor converts `null` to `default(T)`. For `int`, this means `Max=0` — which silently clamps every value to 0, making the field reset to 0 on any edit.
+
+**File:** `src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooNumericField.razor`
+
+## Root Cause
+
+```razor
+Min="@Min"    <!-- Min is T? = null → passed as default(T) = 0 -->
+Max="@Max"    <!-- Max is T? = null → passed as default(T) = 0 -->
+Step="@Step"  <!-- Step is T? = null → passed as default(T) = 0 -->
+```
+
+MudBlazor's `MudNumericField` treats `Max=0` as "clamp to 0", not "no max set".
+
+## Impact
+
+Any `MudNeatooNumericField<int>` (or other numeric type) where the caller does not explicitly set `Max` will silently clamp all values to 0. This manifests as the field resetting to 0 when the user edits it.
+
+Discovered in zTreatment's consultation plan panel — the field loaded correctly but reset to 0 on any user interaction. Took extensive debugging to isolate because the symptom (value goes to 0) appeared to be a rendering/re-render issue.
+
+## Fix
+
+Conditionally omit `Min`/`Max`/`Step` when they are null so MudBlazor uses its own defaults (`T.MinValue`/`T.MaxValue`). This likely requires a `@attributes` dictionary or splitting the render into conditional branches.
+
+Also audit all other MudNeatoo components for the same pattern — any `T?` parameter passed to a MudBlazor `T` parameter has this bug.

--- a/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooNumericField.razor
+++ b/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooNumericField.razor
@@ -20,8 +20,6 @@
                  AdornmentText="@AdornmentText"
                  AdornmentColor="@AdornmentColor"
                  Format="@Format"
-                 Min="@Min"
-                 Max="@Max"
-                 Step="@Step"
                  HideSpinButtons="@HideSpinButtons"
-                 Class="@Class" />
+                 Class="@Class"
+                 @attributes="MinMaxStepAttributes" />

--- a/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooNumericField.razor.cs
+++ b/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooNumericField.razor.cs
@@ -85,19 +85,19 @@ public partial class MudNeatooNumericField<T> : ComponentBase, IDisposable
     public string? Format { get; set; }
 
     /// <summary>
-    /// The minimum allowed value.
+    /// The minimum allowed value. When unset, MudBlazor's default (<c>T.MinValue</c>) is used.
     /// </summary>
     [Parameter]
     public T? Min { get; set; }
 
     /// <summary>
-    /// The maximum allowed value.
+    /// The maximum allowed value. When unset, MudBlazor's default (<c>T.MaxValue</c>) is used.
     /// </summary>
     [Parameter]
     public T? Max { get; set; }
 
     /// <summary>
-    /// The increment/decrement step when using spin buttons.
+    /// The increment/decrement step when using spin buttons. When unset, MudBlazor's default (<c>1</c>) is used.
     /// </summary>
     [Parameter]
     public T? Step { get; set; }
@@ -115,6 +115,22 @@ public partial class MudNeatooNumericField<T> : ComponentBase, IDisposable
     public string? Class { get; set; }
 
     private T? TypedValue => (T?)this.EntityProperty.Value;
+
+    // Splat only the Min/Max/Step values the caller actually set.
+    // Forwarding null would be converted to default(T) (e.g. 0 for int) and silently clamp values --
+    // instead we omit the attribute entirely so MudNumericField uses its own T.MinValue/T.MaxValue/1 defaults.
+    // This works for both non-nullable (int) and nullable (int?) T.
+    private Dictionary<string, object> MinMaxStepAttributes
+    {
+        get
+        {
+            var attrs = new Dictionary<string, object>();
+            if (this.Min is not null) attrs["Min"] = this.Min;
+            if (this.Max is not null) attrs["Max"] = this.Max;
+            if (this.Step is not null) attrs["Step"] = this.Step;
+            return attrs;
+        }
+    }
 
     protected override void OnInitialized()
     {

--- a/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor
+++ b/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor
@@ -13,6 +13,8 @@
               Variant="@Variant"
               Margin="@Margin"
               Lines="@Lines"
+              Sizing="@Sizing"
+              MaxLines="@MaxLines"
               HelperText="@HelperText"
               HelperTextOnFocus="@HelperTextOnFocus"
               Placeholder="@Placeholder"

--- a/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor.cs
+++ b/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor.cs
@@ -43,6 +43,18 @@ public partial class MudNeatooTextField<T> : ComponentBase, IDisposable
     public int Lines { get; set; } = 1;
 
     /// <summary>
+    /// The resizing behavior of the input. Use <see cref="InputSizing.Auto"/> for a textarea that grows with its content (requires <see cref="Lines"/> &gt; 1).
+    /// </summary>
+    [Parameter]
+    public InputSizing Sizing { get; set; } = InputSizing.Fixed;
+
+    /// <summary>
+    /// The maximum number of lines the textarea will grow to when <see cref="Sizing"/> is <see cref="InputSizing.Auto"/>. 0 means unlimited.
+    /// </summary>
+    [Parameter]
+    public int MaxLines { get; set; }
+
+    /// <summary>
     /// Helper text displayed below the input.
     /// </summary>
     [Parameter]


### PR DESCRIPTION
## Summary

- **Feature**: `MudNeatooTextField` exposes MudBlazor 9's `Sizing` (`InputSizing`) and `MaxLines` for auto-growing multiline textareas
- **Fix**: `MudNeatooNumericField` no longer silently clamps values to `0` when `Min`/`Max`/`Step` are left unset
- **Version**: 0.28.1 → 0.29.0 (minor)

## The bug

`MudNeatooNumericField<T>` was passing `Min`/`Max`/`Step` (typed `T?`, defaulting to `null`) straight through to `MudNumericField<T>`. Blazor's attribute binding converted null → `default(T)`, which for `int` is `0`. MudBlazor treated `Max=0` as a real upper bound and silently clamped every value to `0` — the field appeared to reset on any user interaction. Took extensive debugging in zTreatment to isolate (originally looked like a rendering issue).

## The fix

Splat `Min`/`Max`/`Step` into `MudNumericField` via `@attributes` dictionary — only include keys when the caller explicitly set them. Unset values are omitted entirely, letting MudBlazor apply its own `T.MinValue`/`T.MaxValue`/`1` defaults via its internal converter dispatcher. No generic constraint needed → works for both `int` and `int?`.

## Test plan

- [ ] Verify `<MudNeatooNumericField T="int" EntityProperty="..." />` with no Min/Max accepts arbitrary integer values (does not clamp to 0)
- [ ] Verify `<MudNeatooNumericField T="int?" EntityProperty="..." />` still compiles and supports null entry
- [ ] Verify `<MudNeatooTextField T="string" Lines="3" Sizing="InputSizing.Auto" MaxLines="10" />` grows as content is typed

🤖 Generated with [Claude Code](https://claude.com/claude-code)