### PR TITLE
feat: MudNeatooTextField UserAttributes; bump to 0.30.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>0.29.0</Version>
+		<Version>0.30.0</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/docs/plans/completed/mudneatoo-textfield-userattributes.md
+++ b/docs/plans/completed/mudneatoo-textfield-userattributes.md
@@ -1,0 +1,120 @@
+# MudNeatooTextField UserAttributes parameter
+
+**Date:** 2026-04-13
+**Related Todo:** [MudNeatooTextField: Add UserAttributes escape hatch](../../todos/completed/mudneatoo-textfield-userattributes.md)
+**Status:** Complete
+**Last Updated:** 2026-04-13
+
+---
+
+## Overview
+
+Add a single `UserAttributes` pass-through parameter to `MudNeatooTextField<T>` so callers can set arbitrary HTML attributes (`spellcheck`, inline `style`, etc.) on the underlying `<input>`/`<textarea>`. No behavioral logic. No domain-model impact.
+
+---
+
+## Skills
+
+- `skills/mudneatoo/SKILL.md` — documents the MudNeatoo component wrappers; needs a note on the new parameter and an example.
+
+---
+
+## Business Rules (Testable Assertions)
+
+This change has no domain business rules. It is a pure UI pass-through of a MudBlazor component parameter. The only correctness criterion is mechanical:
+
+1. WHEN a consumer sets `UserAttributes` on `MudNeatooTextField`, THEN those attributes reach the rendered native `<input>` or `<textarea>` — Source: NEW (follows existing pass-through parameter convention already used for `Variant`, `Margin`, `Lines`, `Sizing`, `MaxLines`, etc.)
+
+### Test Scenarios
+
+No new automated tests. Verification is by build + existing test suite staying green. Manual verification:
+
+| # | Scenario | Inputs / State | Rule(s) | Expected Result |
+|---|----------|---------------|---------|-----------------|
+| 1 | Consumer sets spellcheck | `UserAttributes=@(new() { ["spellcheck"] = "true" })` on a multiline field | Rule 1 | Rendered `<textarea>` has `spellcheck="true"` attribute |
+| 2 | Consumer sets inline style | `UserAttributes=@(new() { ["style"] = "resize: vertical;" })` on a multiline field with `Sizing=Fixed` | Rule 1 | Rendered `<textarea>` has `style="resize: vertical;"` — user gets drag handle |
+| 3 | No UserAttributes set | Parameter omitted entirely | Rule 1 | No change in rendered output vs. 0.29.0 — backward compatible |
+
+Scenarios 1 and 2 are verified by the consuming application (zTreatment), not by unit tests in this repo.
+
+---
+
+## Approach
+
+One new `[Parameter]` on `MudNeatooTextField<T>`: `Dictionary<string, object>? UserAttributes`. Forwarded to the child `MudTextField` via `UserAttributes="@UserAttributes"`. MudBlazor's `MudInput` already spreads `UserAttributes` onto the native element — no additional plumbing required.
+
+This matches the shape of `UserAttributes` on `MudComponentBase` (`IReadOnlyDictionary<string, object?>` in source, but the public surface uses `Dictionary<string, object>`). We mirror the MudBlazor public type exactly to avoid surprising consumers.
+
+---
+
+## Domain Model Behavioral Design
+
+Not applicable — this is a UI-layer pass-through parameter with no domain semantics.
+
+---
+
+## Design
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor.cs` | Add `[Parameter] public Dictionary<string, object>? UserAttributes { get; set; }` with XML summary |
+| `src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor` | Add `UserAttributes="@UserAttributes"` attribute on the `<MudTextField>` element |
+| `Directory.Build.props` | `<Version>` 0.29.0 → 0.30.0 |
+| `docs/release-notes/v0.30.0.md` | New release notes file following the v0.29.0 template |
+| `skills/mudneatoo/SKILL.md` | Add `UserAttributes` to the component's parameter reference and an example showing `spellcheck` + `resize: vertical` |
+
+### MudBlazor verification summary
+
+- Installed `MudBlazor 9.0.0` XML docs: `MudComponentBase.UserAttributes` present; no `Spellcheck` property on `MudTextField`/`MudInput`.
+- Current `MudBlazor/dev` source (`MudInput.razor`): native `<input>` and `<textarea>` both receive `@attributes="UserAttributes"`. Confirms the pass-through reaches the element.
+
+### Parameter type choice: `Dictionary<string, object>` vs `IReadOnlyDictionary<string, object?>`
+
+Use `Dictionary<string, object>` to match MudBlazor's public `UserAttributes` signature (`MudComponentBase.UserAttributes` is typed as `Dictionary<string, object>`). A more defensive `IReadOnlyDictionary<string, object?>` would require a cast or copy on forwarding and would diverge from every example in MudBlazor's own docs. Keep it identical to MudBlazor.
+
+Default value: `null` (not an empty dictionary). Matches MudBlazor's default and avoids allocating an empty dictionary for every field.
+
+---
+
+## Implementation Steps
+
+1. Edit `MudNeatooTextField.razor.cs`: add `[Parameter] public Dictionary<string, object>? UserAttributes { get; set; }` with an XML summary describing the escape-hatch semantics, mentioning spellcheck and inline style as example use cases.
+2. Edit `MudNeatooTextField.razor`: add `UserAttributes="@UserAttributes"` on the `<MudTextField>` element. Keep alphabetical ordering unchanged from current file (append before `Class="@Class"` to stay at bottom, or place after `AdornmentColor`; pick whichever keeps the diff minimal).
+3. Bump `<Version>` in `Directory.Build.props` from `0.29.0` to `0.30.0`.
+4. Create `docs/release-notes/v0.30.0.md` following v0.29.0's structure.
+5. Update `skills/mudneatoo/SKILL.md` to document `UserAttributes` and include an example combining `Sizing="InputSizing.Auto"`, `spellcheck`, and `style="resize: vertical"`.
+6. `dotnet build src/Neatoo.sln`.
+7. `dotnet test src/Neatoo.sln`.
+8. Invoke `neatoo-developer` agent for code review (Step 5).
+9. Invoke `business-requirements-documenter` agent to review skill and release-notes changes (Step 7).
+10. On green review, mark todo Complete and move to `completed/`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `UserAttributes` compiles and is forwarded to `MudTextField` in the `.razor` file.
+- [ ] Version bumped to 0.30.0 in `Directory.Build.props`.
+- [ ] Release notes `v0.30.0.md` exists and follows the established format.
+- [ ] `skills/mudneatoo/SKILL.md` mentions `UserAttributes` with a working example.
+- [ ] `dotnet build src/Neatoo.sln` succeeds (zero errors, zero warnings given `TreatWarningsAsErrors=true`).
+- [ ] `dotnet test src/Neatoo.sln` passes — same count as before this change.
+- [ ] Developer agent approves.
+- [ ] Documenter agent approves skill + release-notes content.
+
+---
+
+## Dependencies
+
+None. Pure additive change.
+
+---
+
+## Risks / Considerations
+
+- **Nullability annotations.** `Dictionary<string, object>?` (not `Dictionary<string, object?>`). Matches MudBlazor's declaration; changing it would produce a compiler warning at the forwarding site.
+- **No test coverage.** This is a thin pass-through and the project has no Blazor component test harness. Accepted risk: the downstream consuming application (zTreatment) will exercise it in its existing form pages.
+- **Naming conflict with Razor attribute splatting.** `@attributes` and `UserAttributes` are distinct in MudBlazor's model. We are forwarding as a regular `[Parameter]`, not splatting — no conflict.
+- **Skill example placement.** The skill already has several pass-through parameter examples; add the new example near the existing `Sizing`/`MaxLines` reference rather than creating a new section.

--- a/docs/plans/mudneatoo-textfield-userattributes.memory/developer.md
+++ b/docs/plans/mudneatoo-textfield-userattributes.memory/developer.md
@@ -1,0 +1,53 @@
+# Developer — MudNeatooTextField UserAttributes
+
+Last updated: 2026-04-13
+Current step: Post-implementation code review (Step 5)
+
+## Developer Review
+
+**Status:** Approved
+**Reviewed:** 2026-04-13
+
+### Assertion Trace
+
+| Rule | Assertion | Evidence |
+|------|-----------|----------|
+| 1 | Consumer-set `UserAttributes` reaches native `<input>`/`<textarea>` | Declared in `MudNeatooTextField.razor.cs:104-105` as `[Parameter] public Dictionary<string, object>? UserAttributes { get; set; }` (matches MudBlazor's public signature exactly, null default). Forwarded in `MudNeatooTextField.razor:25` as `UserAttributes="@UserAttributes"` on `<MudTextField>`. MudBlazor's `MudInput` spreads `UserAttributes` onto the native element (accepted as given per instructions). End-to-end path intact. |
+
+### Why This Plan Is Exceptionally Clear
+
+- Two-line mechanical change with no domain semantics and no new behavior branches.
+- Parameter type (`Dictionary<string, object>?`) mirrors MudBlazor's `MudComponentBase.UserAttributes` exactly — no conversion, no surprises for consumers.
+- Null default matches MudBlazor convention; no allocation cost when unset.
+- XML summary on the new parameter is accurate and names the two concrete use cases (spellcheck, resize style) that motivated the change.
+- `.razor` forwarding line placed at the bottom per the plan's "keep diff minimal" guidance.
+- Release notes accurately describe the change, include two working examples that match the plan's test scenarios (1 = spellcheck, 2 = resize style), and correctly note MudBlazor does not expose a typed `Spellcheck` parameter.
+- Build passed with zero errors under `TreatWarningsAsErrors=true`, confirming nullability annotations are correct.
+- Full test suite green (2144 passed, 2 pre-existing skipped, 0 failed).
+
+### Concerns
+
+None. The property declaration, Razor forwarding, and release-notes description are all consistent with the plan's single business rule and with each other.
+
+### Verdict
+
+**Approved.** Ready to proceed to architect verification (Step 6).
+
+---
+
+## Grading Pass (2026-04-13)
+
+Overall: **A-**
+
+| Dim | Grade | One-liner |
+|-----|-------|-----------|
+| Plan quality | A- | Complete sections, explicit type-choice rationale, clear trace Rule 1 → .razor.cs:104 → .razor:25; only weakness is scenario table lacks an automated home. |
+| Implementation correctness | A | Declaration at `.razor.cs:104-105` + forwarding at `.razor:25` satisfy Rule 1 end-to-end; XML summary names the two motivating use cases. |
+| Implementation minimalism | A | Two lines changed. No helpers, no wrappers, no merging logic. Nothing to trim. |
+| Type choice | A | `Dictionary<string, object>?` exactly mirrors `MudComponentBase.UserAttributes`; `IReadOnlyDictionary<string, object?>` would force a copy/cast at the forwarding site for no gain. |
+| Doc quality | A | Release notes and skill edits both state the MudBlazor fact (no typed `Spellcheck`), show both use cases, and place the new section adjacent to `Lines`/`Sizing`/`MaxLines` as the plan directed. Opportunistic Multi-line section backfill is a nice bonus. |
+| Backward compatibility | A | Additive parameter, `null` default; matches MudBlazor default so no empty-dict allocation per field. Existing consumers get byte-identical rendering. |
+| Test coverage | B | "No tests" is defensible for a dictionary pass-through with no branching, but the project still has no Blazor render-level harness — and the plan acknowledges rather than solves that. A small bUnit-style smoke check that `UserAttributes` reaches `MudTextField` would cost little and prevent a future Razor-edit regression (someone deleting the forwarding line would go unnoticed by the current suite). Grade reflects accepted risk, not a defect. |
+
+- **Strongest point:** Decisive scope discipline — the plan rejected dedicated `Spellcheck`/`InputStyle` wrappers after verifying MudBlazor's surface, then shipped exactly one parameter that covers both motivating cases.
+- **Notable weakness:** Forwarding is untested at the component level; a trivial edit could silently drop `UserAttributes="@UserAttributes"` without any test failing.

--- a/docs/plans/mudneatoo-textfield-userattributes.memory/requirements-documenter.md
+++ b/docs/plans/mudneatoo-textfield-userattributes.memory/requirements-documenter.md
@@ -1,0 +1,46 @@
+# Requirements Documenter — MudNeatooTextField UserAttributes (0.30.0)
+
+Last updated: 2026-04-13
+Current step: Step 7 review complete
+
+## Key Context
+
+- Pure UI pass-through parameter. No domain business rules. No .cs deliverables.
+- Todo/plan explicitly skipped requirements review (Step 3) — justified.
+- Scope: verify accuracy of release notes and mudneatoo SKILL.md edits.
+
+## Files Reviewed
+
+1. `docs/release-notes/v0.30.0.md` — new, follows v0.29.0 template.
+2. `skills/mudneatoo/SKILL.md` lines 96–125 — two new sections.
+3. `docs/plans/mudneatoo-textfield-userattributes.md` — context.
+4. `docs/todos/index.md` — internal framework-work tracker; does NOT list releases. No update needed.
+
+## Findings
+
+### Release notes v0.30.0.md — Accurate
+
+- Summary matches implementation (single `UserAttributes` forward to `MudTextField`).
+- Version/date/type correct. Links to v0.29.0 and completed todo present.
+- Two razor examples are syntactically valid and demonstrate the two stated use cases.
+- Correctly states MudBlazor has no typed `Spellcheck` parameter (matches plan's MudBlazor 9.0.0 verification).
+
+### SKILL.md additions — Accurate and well-placed
+
+- Placement (right after the pass-through paragraph at line 94) is appropriate — reader is already thinking about pass-through.
+- MudBlazor facts verified against plan's source inspection: `UserAttributes` is a `Dictionary<string, object>?`, `MudInput.razor` splats it onto native `<input>`/`<textarea>`, no typed `Spellcheck` property exists.
+- Examples use correct `@entity[nameof(IPatient.Notes)]` indexer style — matches skill's established binding pattern elsewhere.
+- `Lines`/`Sizing`/`MaxLines` section: Confirmed these parameters were shipped in v0.29.0 but were NOT previously documented in this skill file. Opportunistic backfill is appropriate and non-controversial.
+
+### Gaps — None
+
+- No other docs require updates. `docs/index.md` is getting-started framework overview; MudNeatoo component specifics live only in skill + release notes, which is consistent with how v0.29.0 was handled.
+- No MarkdownSnippets concerns — release notes are excluded from mdsnippets processing (per `.claude/rules/docs.md`), and no user-facing `docs/*.md` page covers MudNeatoo components.
+
+## Developer Deliverables
+
+None. No `.cs` framework-source changes needed for documentation purposes. The razor/cs implementation itself is developer-agent scope and already complete.
+
+## Verdict
+
+**Approved.** Release notes and skill edits are accurate, well-scoped, and appropriately placed. No .cs deliverables. Step 9 Part B can be skipped — no further documentation work.

--- a/docs/release-notes/v0.30.0.md
+++ b/docs/release-notes/v0.30.0.md
@@ -1,0 +1,50 @@
+# Neatoo 0.30.0
+
+**Release Date:** 2026-04-13
+**Type:** Minor
+**Breaking Changes:** No
+
+---
+
+## Summary
+
+MudNeatoo addition:
+
+- `MudNeatooTextField` now forwards a `UserAttributes` dictionary to `MudTextField`, reaching the native `<input>`/`<textarea>` element. Provides an escape hatch for HTML attributes not exposed as typed parameters.
+
+---
+
+## What Changed
+
+### `MudNeatooTextField`: `UserAttributes` parameter
+
+New parameter on `MudNeatooTextField<T>`:
+
+- `UserAttributes` (`Dictionary<string, object>?`, default `null`) — forwarded to `MudTextField.UserAttributes`. MudBlazor's `MudInput` spreads these onto the native `<input>` or `<textarea>`, so any HTML attribute works — `spellcheck`, inline `style`, `autocomplete`, `maxlength`, etc.
+
+Two concrete use cases this unblocks:
+
+```razor
+@* Enable browser spellcheck on a multiline field *@
+<MudNeatooTextField T="string"
+                    EntityProperty="Entity.NotesProperty"
+                    Lines="4"
+                    Sizing="InputSizing.Auto"
+                    MaxLines="20"
+                    UserAttributes="@(new() { ["spellcheck"] = "true" })" />
+
+@* User drag-handle resize on a fixed-height textarea *@
+<MudNeatooTextField T="string"
+                    EntityProperty="Entity.NotesProperty"
+                    Lines="4"
+                    UserAttributes="@(new() { ["style"] = "resize: vertical;" })" />
+```
+
+MudBlazor does not expose a typed `Spellcheck` parameter on `MudTextField` or `MudInput`; `UserAttributes` is the supported mechanism.
+
+---
+
+## Related
+
+- [v0.29.0 - MudNeatooTextField Sizing/MaxLines; MudNeatooNumericField null-clamp fix](v0.29.0.md)
+- [Completed todo](../todos/completed/mudneatoo-textfield-userattributes.md)

--- a/docs/todos/completed/mudneatoo-textfield-userattributes.md
+++ b/docs/todos/completed/mudneatoo-textfield-userattributes.md
@@ -1,0 +1,88 @@
+# MudNeatooTextField: Add UserAttributes escape hatch
+
+**Status:** Complete
+**Priority:** Medium
+**Created:** 2026-04-13
+**Last Updated:** 2026-04-13
+
+---
+
+## Problem
+
+After the 0.29.0 upgrade the user-facing textarea still lacks two browser-level behaviors:
+
+- **Spellcheck**: no way to set `spellcheck="true"` on the underlying `<textarea>`.
+- **User drag-handle resize**: no way to apply `style="resize: vertical"` on the underlying `<textarea>`.
+
+Initial hypothesis was that `MudTextField` exposed a `Spellcheck` parameter we were failing to forward. Verified against MudBlazor 9.0.0 installed package XML docs and current MudBlazor source (`MudTextField.razor`, `MudInput.razor`): **no `Spellcheck` parameter exists on either component.** However, `MudInput` does spread `@attributes="UserAttributes"` onto the native `<input>` and `<textarea>`, and `UserAttributes` is inherited from `MudComponentBase`.
+
+So the real gap is: `MudNeatooTextField` does not forward `UserAttributes` to `MudTextField`, leaving consumers with no escape hatch for native HTML attributes or inline style.
+
+## Solution
+
+Add a single `UserAttributes` parameter to `MudNeatooTextField<T>` and forward it to `MudTextField`. This one parameter covers both requested use cases:
+
+- `spellcheck` → `UserAttributes["spellcheck"] = "true"`
+- drag-handle resize → `UserAttributes["style"] = "resize: vertical;"`
+
+Release as 0.30.0 (minor — new parameter, no breaking changes).
+
+---
+
+## Requirements Review
+
+**Verdict:** SKIPPED (per user — small API-surface addition, no business-rule impact)
+**Reviewed:** —
+**Summary:** —
+
+---
+
+## Plans
+
+- [MudNeatooTextField UserAttributes parameter](../../plans/completed/mudneatoo-textfield-userattributes.md)
+
+---
+
+## Tasks
+
+- [x] Create todo and plan
+- [x] Implement `UserAttributes` parameter in `MudNeatooTextField.razor.cs` and `.razor`
+- [x] Bump version to 0.30.0 in `Directory.Build.props`
+- [x] Write release notes `docs/release-notes/v0.30.0.md`
+- [x] Update `skills/mudneatoo/SKILL.md` with the new parameter and example
+- [x] Build and run tests
+- [x] Developer agent code review (Step 5) — Approved
+- [x] Documenter agent review of skill + release notes (Step 7) — Approved
+
+---
+
+## Progress Log
+
+### 2026-04-13
+- Verified MudBlazor 9.0.0 has no `Spellcheck` parameter on `MudTextField` or `MudInput`.
+- Verified `MudInput.razor` spreads `@attributes="UserAttributes"` onto the native `<textarea>`/`<input>`.
+- Chose option 1: single `UserAttributes` parameter as the escape hatch.
+- User opted to skip requirements review and architect validation — scope is a single pass-through parameter with no domain impact.
+- Next: implement, then run developer + documenter agents.
+
+---
+
+## Completion Verification
+
+Before marking this todo as Complete, verify:
+
+- [x] All builds pass
+- [x] All tests pass
+
+**Verification results:**
+- Build: 0 errors, 474 pre-existing warnings (all in test projects).
+- Tests: 2144 passed, 2 skipped (pre-existing), 0 failed.
+
+---
+
+## Results / Conclusions
+
+- **MudBlazor fact established**: `MudTextField` and `MudInput` have no typed `Spellcheck` parameter in 9.0.0 or current `dev`. `UserAttributes` (inherited from `MudComponentBase`) is the supported mechanism — MudBlazor spreads it onto the native `<input>`/`<textarea>` via `@attributes="UserAttributes"`.
+- **Single-parameter solution**: One `UserAttributes` pass-through handles both of the user's requested behaviors (spellcheck, drag-handle resize). No need for dedicated `Spellcheck` / `InputStyle` convenience wrappers.
+- **Signature mirrors MudBlazor**: `Dictionary<string, object>?` default `null` matches `MudComponentBase.UserAttributes` exactly, so forwarding is one line with no conversion.
+- **Opportunistic skill backfill**: `Lines`/`Sizing`/`MaxLines` from 0.29.0 had never been documented in `skills/mudneatoo/SKILL.md`. Added a "Multi-line text" section alongside the new `UserAttributes` section.

--- a/skills/mudneatoo/SKILL.md
+++ b/skills/mudneatoo/SKILL.md
@@ -93,6 +93,37 @@ See `references/anti-patterns.md` for the complete anti-pattern catalog with rea
 
 All MudBlazor parameters pass through — `Variant`, `Margin`, `HelperText`, `Adornment`, `Class`, `Min`, `Max`, etc. — **except `ReadOnly`** (hardcoded to `EntityProperty.IsReadOnly`; see ReadOnly Behavior below) and **`Disabled`** (OR'd with `EntityProperty.IsBusy`; see Disabled Behavior below).
 
+### `MudNeatooTextField` escape hatch: `UserAttributes`
+
+`MudNeatooTextField<T>` forwards a `UserAttributes` (`Dictionary<string, object>?`) parameter to `MudTextField`. MudBlazor spreads the dictionary onto the native `<input>` or `<textarea>`, so any HTML attribute works — including ones with no typed MudBlazor parameter. Use it for:
+
+- **Spellcheck** — MudBlazor does NOT expose a `Spellcheck` parameter on `MudTextField` or `MudInput`. Set `["spellcheck"] = "true"` via `UserAttributes`.
+- **Drag-handle resize** — CSS `resize: vertical` on the `<textarea>`. Set `["style"] = "resize: vertical;"` via `UserAttributes`.
+
+```razor
+@* Auto-growing textarea with browser spellcheck *@
+<MudNeatooTextField T="string"
+                    EntityProperty="@entity[nameof(IPatient.Notes)]"
+                    Lines="4"
+                    Sizing="InputSizing.Auto"
+                    MaxLines="20"
+                    UserAttributes="@(new() { ["spellcheck"] = "true" })" />
+
+@* Fixed-height textarea with user drag handle *@
+<MudNeatooTextField T="string"
+                    EntityProperty="@entity[nameof(IPatient.Notes)]"
+                    Lines="4"
+                    UserAttributes="@(new() { ["style"] = "resize: vertical;" })" />
+```
+
+### Multi-line text: `Lines`, `Sizing`, `MaxLines`
+
+`MudNeatooTextField<T>` also forwards MudBlazor's multi-line parameters:
+
+- `Lines` (`int`, default `1`) — set greater than `1` for a `<textarea>`.
+- `Sizing` (`InputSizing`, default `Fixed`) — `InputSizing.Auto` grows the textarea with its content (requires `Lines > 1`).
+- `MaxLines` (`int`, default `0`) — upper bound on auto-grow. `0` means unlimited.
+
 ## Binding Patterns
 
 ### Text and Numeric Fields

--- a/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor
+++ b/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor
@@ -21,4 +21,5 @@
               Adornment="@Adornment"
               AdornmentIcon="@AdornmentIcon"
               AdornmentColor="@AdornmentColor"
-              Class="@Class" />
+              Class="@Class"
+              UserAttributes="@UserAttributes" />

--- a/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor.cs
+++ b/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
-using Neatoo;
 using System.ComponentModel;
 
 namespace Neatoo.Blazor.MudNeatoo.Components;
@@ -95,6 +94,15 @@ public partial class MudNeatooTextField<T> : ComponentBase, IDisposable
     /// </summary>
     [Parameter]
     public string? Class { get; set; }
+
+    /// <summary>
+    /// Arbitrary HTML attributes forwarded to the underlying MudBlazor component, which
+    /// spreads them onto the native <c>&lt;input&gt;</c> or <c>&lt;textarea&gt;</c> element.
+    /// Use this as an escape hatch for attributes not exposed as typed parameters --
+    /// for example <c>spellcheck="true"</c> or <c>style="resize: vertical;"</c>.
+    /// </summary>
+    [Parameter]
+    public Dictionary<string, object>? UserAttributes { get; set; }
 
     private T? TypedValue => (T?)this.EntityProperty.Value;
 


### PR DESCRIPTION
## Summary

- Adds a `UserAttributes` (`Dictionary<string, object>?`) parameter to `MudNeatooTextField<T>`, forwarded to `MudTextField` and spread onto the native `<input>`/`<textarea>`.
- Covers both spellcheck and drag-handle resize via one escape hatch. MudBlazor 9.0.0 does not expose a typed `Spellcheck` parameter on `MudTextField` or `MudInput`; `UserAttributes` is the supported path.
- Version bumped to 0.30.0. Release notes added. `skills/mudneatoo/SKILL.md` gains a `UserAttributes` section plus a backfilled `Lines`/`Sizing`/`MaxLines` section that was missing from 0.29.0.

## Usage

```razor
<MudNeatooTextField T="string"
                    EntityProperty="@entity[nameof(IPatient.Notes)]"
                    Lines="4"
                    Sizing="InputSizing.Auto"
                    MaxLines="20"
                    UserAttributes="@(new() { ["spellcheck"] = "true" })" />
```

## Test plan

- [x] `dotnet build src/Neatoo.sln` — 0 errors
- [x] `dotnet test src/Neatoo.sln` — 2144 passed, 2 skipped (pre-existing), 0 failed
- [ ] Downstream consumer verifies rendered `<textarea>` receives `spellcheck` / `style` attributes
- [ ] Tag `v0.30.0` after merge to trigger NuGet publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)