### PR TITLE
fix: MudNeatooTextField null UserAttributes crash (0.30.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>0.30.0</Version>
+		<Version>0.30.1</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Neatoo 0.29.0** (2026-04-13)
+**Neatoo 0.30.1** (2026-04-14)
 
 ---
 
@@ -12,6 +12,8 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date | Type | Summary |
 |---------|------|------|---------|
+| [0.30.1](v0.30.1.md) | 2026-04-14 | Bug Fix | MudNeatooTextField no longer forwards `null` `UserAttributes`; fixes MudBlazor `ArgumentNullException` on init |
+| [0.30.0](v0.30.0.md) | 2026-04-13 | Feature | MudNeatooTextField `UserAttributes` escape hatch for native HTML attributes |
 | [0.29.0](v0.29.0.md) | 2026-04-13 | Feature + Fix | MudNeatooTextField `Sizing`/`MaxLines`; MudNeatooNumericField no longer clamps to 0 when Min/Max/Step unset |
 | [0.28.1](v0.28.1.md) | 2026-04-12 | Bug Fix | `PropertyInfoWrapper` attribute caches thread-safe; fixes shared-wrapper Dictionary corruption under concurrent load |
 | [0.28.0](v0.28.0.md) | 2026-04-08 | Feature | `Logger` is now `ILogger<T>` for consumer logging |
@@ -56,6 +58,10 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date |
 |---------|------|
+| [0.30.1](v0.30.1.md) | 2026-04-14 |
+| [0.30.0](v0.30.0.md) | 2026-04-13 |
+| [0.29.0](v0.29.0.md) | 2026-04-13 |
+| [0.28.1](v0.28.1.md) | 2026-04-12 |
 | [0.28.0](v0.28.0.md) | 2026-04-08 |
 | [0.27.0](v0.27.0.md) | 2026-04-06 |
 | [0.26.1](v0.26.1.md) | 2026-04-04 |

--- a/docs/release-notes/v0.30.1.md
+++ b/docs/release-notes/v0.30.1.md
@@ -1,0 +1,42 @@
+# Neatoo 0.30.1
+
+**Release Date:** 2026-04-14
+**Type:** Patch
+**Breaking Changes:** No
+
+---
+
+## Summary
+
+Bug fix for `MudNeatooTextField` (0.30.0):
+
+- `MudNeatooTextField<T>` no longer forwards a `null` `UserAttributes` dictionary to the inner `MudTextField`. Rendering the field under MudBlazor 9.1+ would throw `ArgumentNullException` from `MudBaseInput.OnInitializedAsync`, typically surfacing as a blank page when a dialog containing the field opened.
+
+---
+
+## What Changed
+
+### `MudNeatooTextField.UserAttributes` defaults to an empty dictionary
+
+The 0.30.0 release added a `UserAttributes` escape hatch parameter with a nullable type and a `null` default. The razor template forwarded that value unconditionally to `MudTextField.UserAttributes`, overriding MudBlazor's own non-null default with `null`. `MudBaseInput<T>.OnInitializedAsync` then dereferenced it without a null check:
+
+```csharp
+_userAttributesId = base.UserAttributes.FirstOrDefault(...).Value?.ToString();
+```
+
+…which threw `ArgumentNullException("source")` on first render. Any dialog or page hosting a `MudNeatooTextField` without explicitly passing `UserAttributes` crashed during init.
+
+The parameter is now non-nullable and initialized to `new Dictionary<string, object>()`, matching MudBlazor's own `MudComponentBase.UserAttributes` convention:
+
+```csharp
+[Parameter]
+public Dictionary<string, object> UserAttributes { get; set; } = new();
+```
+
+Consumers passing attributes explicitly are unaffected. Consumers who were explicitly passing `null` will now get a compile-time error instead of a runtime crash.
+
+---
+
+## Related
+
+- [v0.30.0 - MudNeatooTextField UserAttributes escape hatch](v0.30.0.md)

--- a/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor.cs
+++ b/src/Neatoo.Blazor.MudNeatoo/Components/MudNeatooTextField.razor.cs
@@ -102,7 +102,7 @@ public partial class MudNeatooTextField<T> : ComponentBase, IDisposable
     /// for example <c>spellcheck="true"</c> or <c>style="resize: vertical;"</c>.
     /// </summary>
     [Parameter]
-    public Dictionary<string, object>? UserAttributes { get; set; }
+    public Dictionary<string, object> UserAttributes { get; set; } = new();
 
     private T? TypedValue => (T?)this.EntityProperty.Value;
 


### PR DESCRIPTION
## Summary

- 0.30.0's `MudNeatooTextField<T>.UserAttributes` was nullable with a `null` default, and the razor unconditionally forwarded it to `MudTextField.UserAttributes`, overriding MudBlazor's own non-null default.
- `MudBaseInput<T>.OnInitializedAsync` then threw `ArgumentNullException("source")` on the first render of any `MudNeatooTextField`, typically surfacing as a blank page when a dialog hosting the field opened.
- Fix: default `UserAttributes` to `new Dictionary<string, object>()`, matching `MudComponentBase`'s convention. Parameter is now non-nullable.

## Test plan

- [x] Full test run clean: BaseGenerator.Tests (42), Samples (254), Person.DomainModel.Tests (55), Neatoo.UnitTest (1793, 2 pre-existing skips), Design.Tests (104) — 0 failures.
- [ ] Consumer smoke test: dialog with `MudNeatooTextField` renders without crashing under MudBlazor 9.1+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)