### PR TITLE
docs: clarify IsModified/IsNew relationship, remove DoMark from skill

### DIFF
--- a/docs/guides/collections.md
+++ b/docs/guides/collections.md
@@ -140,35 +140,17 @@ Remove items from EntityListBase:
 <!-- snippet: collections-remove-entity -->
 <a id='snippet-collections-remove-entity'></a>
 ```cs
-[Fact]
-public void RemoveFromEntityList_TracksForDeletion()
-{
-    var orderFactory = GetRequiredService<ICollectionOrderFactory>();
-    var order = orderFactory.Create();
+// Remove from EntityListBase - existing item goes to DeletedList
+order.Items.Remove(item);
 
-    // Create an "existing" item (simulating loaded from database)
-    var itemFactory = GetRequiredService<ICollectionOrderItemFactory>();
-    var item = itemFactory.Fetch("WIDGET-001", 19.99m, 1);
+// Item removed from active list
+Assert.Empty(order.Items);
 
-    // Add fetched item to order
-    order.Items.Add(item);
-    order.DoMarkUnmodified();
-
-    Assert.Single(order.Items);
-    Assert.False(item.IsNew);
-
-    // Remove from EntityListBase - existing item goes to DeletedList
-    order.Items.Remove(item);
-
-    // Item removed from active list
-    Assert.Empty(order.Items);
-
-    // Item is marked deleted and tracked for persistence
-    Assert.True(item.IsDeleted);
-    Assert.Equal(1, order.Items.DeletedCount);
-}
+// Item is marked deleted and tracked for persistence
+Assert.True(item.IsDeleted);
+Assert.Equal(1, order.Items.DeletedCount);
 ```
-<sup><a href='/src/samples/CollectionsSamples.cs#L181-L209' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-remove-entity' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/CollectionsSamples.cs#L198-L208' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-remove-entity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The sample uses `DoMarkUnmodified()`, a helper method that exposes the protected `MarkUnmodified()` for demonstration purposes. In production, `MarkUnmodified()` is called automatically by the framework after Fetch or successful save operations.
@@ -422,33 +404,15 @@ The DeletedList lifecycle:
 <!-- snippet: collections-deleted-list -->
 <a id='snippet-collections-deleted-list'></a>
 ```cs
-[Fact]
-public void DeletedList_TracksRemovedEntitiesUntilSave()
-{
-    var orderFactory = GetRequiredService<ICollectionOrderFactory>();
-    var order = orderFactory.Create();
+// Remove an item - goes to DeletedList
+order.Items.Remove(item1);
+Assert.True(item1.IsDeleted);
+Assert.Equal(1, order.Items.DeletedCount);
 
-    var itemFactory = GetRequiredService<ICollectionOrderItemFactory>();
-
-    // Create "existing" items (simulating loaded from database)
-    var item1 = itemFactory.Fetch("ITEM-001", 10m, 1);
-    var item2 = itemFactory.Fetch("ITEM-002", 20m, 2);
-
-    // Add fetched items
-    order.Items.Add(item1);
-    order.Items.Add(item2);
-    order.DoMarkUnmodified();
-
-    // Remove an item - goes to DeletedList
-    order.Items.Remove(item1);
-    Assert.True(item1.IsDeleted);
-    Assert.Equal(1, order.Items.DeletedCount);
-
-    // Collection is modified because of DeletedList
-    Assert.True(order.Items.IsModified);
-}
+// Collection is modified because of DeletedList
+Assert.True(order.Items.IsModified);
 ```
-<sup><a href='/src/samples/CollectionsSamples.cs#L347-L373' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-deleted-list' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/CollectionsSamples.cs#L364-L372' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-deleted-list' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Deleted items remain in DeletedList with their ContainingList property set until FactoryComplete fires after a successful save. This preserves aggregate boundaries during the save operation:

--- a/skills/neatoo/SKILL.md
+++ b/skills/neatoo/SKILL.md
@@ -93,12 +93,12 @@ See `references/domain-logic-placement.md` for detailed patterns: computed prope
 
 | Property | Type | Meaning |
 |----------|------|---------|
-| `IsModified` | bool | Has unsaved changes (this or children) |
-| `IsSelfModified` | bool | This object (only) has changes |
+| `IsModified` | bool | Needs persistence: `PropertyManager.IsModified \|\| IsDeleted \|\| IsNew \|\| IsSelfModified`. True after Create (because IsNew), false after Fetch. |
+| `IsSelfModified` | bool | This object's own properties changed (excludes children, excludes IsNew) |
 | `IsValid` | bool | This object and all children pass validation |
 | `IsSelfValid` | bool | This object (only) passes validation |
 | `IsSavable` | bool | `IsValid && IsModified && !IsBusy && !IsChild` |
-| `IsNew` | bool | Not yet persisted |
+| `IsNew` | bool | Not yet persisted. Set true by Create, set false by Fetch/Insert. Implies `IsModified`. |
 | `IsDeleted` | bool | Marked for deletion |
 | `RuleManager` | IRuleManager | Access to validation rules |
 

--- a/skills/neatoo/references/collections.md
+++ b/skills/neatoo/references/collections.md
@@ -58,35 +58,17 @@ Remove items from entity collections (tracks for deletion):
 <!-- snippet: collections-remove-entity -->
 <a id='snippet-collections-remove-entity'></a>
 ```cs
-[Fact]
-public void RemoveFromEntityList_TracksForDeletion()
-{
-    var orderFactory = GetRequiredService<ICollectionOrderFactory>();
-    var order = orderFactory.Create();
+// Remove from EntityListBase - existing item goes to DeletedList
+order.Items.Remove(item);
 
-    // Create an "existing" item (simulating loaded from database)
-    var itemFactory = GetRequiredService<ICollectionOrderItemFactory>();
-    var item = itemFactory.Fetch("WIDGET-001", 19.99m, 1);
+// Item removed from active list
+Assert.Empty(order.Items);
 
-    // Add fetched item to order
-    order.Items.Add(item);
-    order.DoMarkUnmodified();
-
-    Assert.Single(order.Items);
-    Assert.False(item.IsNew);
-
-    // Remove from EntityListBase - existing item goes to DeletedList
-    order.Items.Remove(item);
-
-    // Item removed from active list
-    Assert.Empty(order.Items);
-
-    // Item is marked deleted and tracked for persistence
-    Assert.True(item.IsDeleted);
-    Assert.Equal(1, order.Items.DeletedCount);
-}
+// Item is marked deleted and tracked for persistence
+Assert.True(item.IsDeleted);
+Assert.Equal(1, order.Items.DeletedCount);
 ```
-<sup><a href='/src/samples/CollectionsSamples.cs#L181-L209' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-remove-entity' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/CollectionsSamples.cs#L198-L208' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-remove-entity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For validate-only collections (ValidateListBase), items are simply removed:
@@ -290,33 +272,15 @@ Entity collections track deleted items:
 <!-- snippet: collections-deleted-list -->
 <a id='snippet-collections-deleted-list'></a>
 ```cs
-[Fact]
-public void DeletedList_TracksRemovedEntitiesUntilSave()
-{
-    var orderFactory = GetRequiredService<ICollectionOrderFactory>();
-    var order = orderFactory.Create();
+// Remove an item - goes to DeletedList
+order.Items.Remove(item1);
+Assert.True(item1.IsDeleted);
+Assert.Equal(1, order.Items.DeletedCount);
 
-    var itemFactory = GetRequiredService<ICollectionOrderItemFactory>();
-
-    // Create "existing" items (simulating loaded from database)
-    var item1 = itemFactory.Fetch("ITEM-001", 10m, 1);
-    var item2 = itemFactory.Fetch("ITEM-002", 20m, 2);
-
-    // Add fetched items
-    order.Items.Add(item1);
-    order.Items.Add(item2);
-    order.DoMarkUnmodified();
-
-    // Remove an item - goes to DeletedList
-    order.Items.Remove(item1);
-    Assert.True(item1.IsDeleted);
-    Assert.Equal(1, order.Items.DeletedCount);
-
-    // Collection is modified because of DeletedList
-    Assert.True(order.Items.IsModified);
-}
+// Collection is modified because of DeletedList
+Assert.True(order.Items.IsModified);
 ```
-<sup><a href='/src/samples/CollectionsSamples.cs#L347-L373' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-deleted-list' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/CollectionsSamples.cs#L364-L372' title='Snippet source file'>snippet source</a> | <a href='#snippet-collections-deleted-list' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Deletion State Behavior

--- a/skills/neatoo/references/entities.md
+++ b/skills/neatoo/references/entities.md
@@ -6,7 +6,7 @@
 
 ### Creating New Entities
 
-New entities have `IsNew = true` until saved:
+After Create: `IsNew = true` and `IsModified = true` (because `IsModified` includes `IsNew` in its formula — a new object needs to be persisted). After Fetch: `IsNew = false` and `IsModified = false` (the object matches its persisted state).
 
 <!-- snippet: entities-is-new -->
 <a id='snippet-entities-is-new'></a>
@@ -208,36 +208,23 @@ public void ModificationState_TracksChanges()
 <sup><a href='/src/samples/EntitiesSamples.cs#L532-L557' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-modification-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-### Marking Clean/Dirty
+### Marking Modified
 
-Manually control dirty state:
+`MarkModified()` is a **protected** method on `EntityBase`. Call it from within the entity to force `IsModified = true` without changing any properties (e.g., to trigger a timestamp update on save):
 
-<!-- snippet: entities-mark-modified -->
-<a id='snippet-entities-mark-modified'></a>
-```cs
-[Fact]
-public void MarkModified_ForcesEntityToBeSaved()
+```csharp
+// Inside entity class — MarkModified() is protected
+[Update]
+internal async Task Update([Service] IRepository repo)
 {
-    var factory = GetRequiredService<IEntitiesOrderFactory>();
+    // ... persist
+}
 
-    // Fetch existing order
-    var order = factory.Fetch(1, "ORD-001", DateTime.Today);
-
-    Assert.False(order.IsModified);
-    Assert.False(order.IsMarkedModified);
-
-    // Force entity to be saved (e.g., timestamp update)
-    order.DoMarkModified();
-
-    Assert.True(order.IsModified);
-    Assert.True(order.IsSelfModified);
-    Assert.True(order.IsMarkedModified);
+public void TouchForSave()
+{
+    MarkModified(); // Forces IsSavable = true even with no property changes
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L559-L578' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-mark-modified' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-<!-- snippet: entities-mark-unmodified -->
-<!-- endSnippet -->
 
 ## Persistence State
 

--- a/src/samples/CollectionsSamples.cs
+++ b/src/samples/CollectionsSamples.cs
@@ -178,7 +178,6 @@ public class CollectionsSamplesTests : SamplesTestBase
     }
     #endregion
 
-    #region collections-remove-entity
     [Fact]
     public void RemoveFromEntityList_TracksForDeletion()
     {
@@ -196,6 +195,7 @@ public class CollectionsSamplesTests : SamplesTestBase
         Assert.Single(order.Items);
         Assert.False(item.IsNew);
 
+        #region collections-remove-entity
         // Remove from EntityListBase - existing item goes to DeletedList
         order.Items.Remove(item);
 
@@ -205,8 +205,8 @@ public class CollectionsSamplesTests : SamplesTestBase
         // Item is marked deleted and tracked for persistence
         Assert.True(item.IsDeleted);
         Assert.Equal(1, order.Items.DeletedCount);
+        #endregion
     }
-    #endregion
 
     #region collections-parent-cascade
     [Fact]
@@ -344,7 +344,6 @@ public class CollectionsSamplesTests : SamplesTestBase
     }
     #endregion
 
-    #region collections-deleted-list
     [Fact]
     public void DeletedList_TracksRemovedEntitiesUntilSave()
     {
@@ -362,6 +361,7 @@ public class CollectionsSamplesTests : SamplesTestBase
         order.Items.Add(item2);
         order.DoMarkUnmodified();
 
+        #region collections-deleted-list
         // Remove an item - goes to DeletedList
         order.Items.Remove(item1);
         Assert.True(item1.IsDeleted);
@@ -369,6 +369,6 @@ public class CollectionsSamplesTests : SamplesTestBase
 
         // Collection is modified because of DeletedList
         Assert.True(order.Items.IsModified);
+        #endregion
     }
-    #endregion
 }


### PR DESCRIPTION
## Summary
- Clarified that `IsModified` includes `IsNew` in its formula — a Created entity is always `IsModified=true`, a Fetched entity starts `IsModified=false`
- Tightened `#region` snippet boundaries in `CollectionsSamples.cs` to exclude `DoMarkUnmodified` test setup from rendered snippets
- Replaced `entities-mark-modified` snippet with hand-written block showing the real protected `MarkModified()` API

## Test plan
- [x] `dotnet build src/samples/samples.csproj` passes
- [x] `dotnet test src/samples/samples.csproj` — 254 tests pass
- [x] `dotnet mdsnippets` regenerates cleanly
- [x] Zero `DoMark` references remain in skill files

🤖 Generated with [Claude Code](https://claude.com/claude-code)