### PR TITLE
fix: AreSame uses value equality for reference types (0.30.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>0.30.1</Version>
+		<Version>0.30.2</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="MudBlazor" Version="9.0.0" />
     <!-- Neatoo Dependencies -->
     <PackageVersion Include="Neatoo" Version="9.10.1" />
-    <PackageVersion Include="Neatoo.RemoteFactory" Version="1.1.0" />
-    <PackageVersion Include="Neatoo.RemoteFactory.AspNetCore" Version="1.1.0" />
+    <PackageVersion Include="Neatoo.RemoteFactory" Version="1.6.1" />
+    <PackageVersion Include="Neatoo.RemoteFactory.AspNetCore" Version="1.6.1" />
     <!-- Testing - MSTest -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Neatoo 0.30.1** (2026-04-14)
+**Neatoo 0.30.2** (2026-05-24)
 
 ---
 
@@ -12,6 +12,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date | Type | Summary |
 |---------|------|------|---------|
+| [0.30.2](v0.30.2.md) | 2026-05-24 | Bug Fix + Dependency | `AreSame<P>` uses value equality for reference types — equal-content string writes no longer flip `IsModified`; RemoteFactory 1.6.1 |
 | [0.30.1](v0.30.1.md) | 2026-04-14 | Bug Fix | MudNeatooTextField no longer forwards `null` `UserAttributes`; fixes MudBlazor `ArgumentNullException` on init |
 | [0.30.0](v0.30.0.md) | 2026-04-13 | Feature | MudNeatooTextField `UserAttributes` escape hatch for native HTML attributes |
 | [0.29.0](v0.29.0.md) | 2026-04-13 | Feature + Fix | MudNeatooTextField `Sizing`/`MaxLines`; MudNeatooNumericField no longer clamps to 0 when Min/Max/Step unset |
@@ -58,6 +59,7 @@ New features, breaking changes, and significant bug fixes.
 
 | Version | Date |
 |---------|------|
+| [0.30.2](v0.30.2.md) | 2026-05-24 |
 | [0.30.1](v0.30.1.md) | 2026-04-14 |
 | [0.30.0](v0.30.0.md) | 2026-04-13 |
 | [0.29.0](v0.29.0.md) | 2026-04-13 |

--- a/docs/release-notes/v0.30.2.md
+++ b/docs/release-notes/v0.30.2.md
@@ -1,0 +1,66 @@
+# Neatoo 0.30.2
+
+**Release Date:** 2026-05-24
+**Type:** Patch
+**Breaking Changes:** No
+
+---
+
+## Summary
+
+- Bug fix: `ValidateProperty<T>.AreSame<P>` now uses value equality (`EqualityComparer<P>.Default`) instead of `ReferenceEquals` for reference-type comparisons. Writes of content-equal but distinct `string` instances (typically produced by JSON deserialization) no longer flip `IsSelfModified` / `IsModified`.
+- Dependency: `Neatoo.RemoteFactory` and `Neatoo.RemoteFactory.AspNetCore` updated from `1.1.0` to `1.6.1`.
+
+---
+
+## What Changed
+
+### `AreSame<P>` value equality for reference types
+
+`ValidateProperty<T>.HandleNonNullValue` short-circuits when the incoming value matches the existing one. The comparison ran through `AreSame<P>`, which for any reference type — including `string` — used `ReferenceEquals`:
+
+```csharp
+if (!typeof(P).IsValueType)
+    return ReferenceEquals(oldValue, newValue);
+else
+    return oldValue.Equals(newValue);
+```
+
+For value types, `Equals` did the right thing. For reference types whose equality is by value (notably `string`), two content-equal instances from independent allocations compared as different. The most common production trigger was a post-deserialization mirror write across two entities loaded from separate JSON payloads — e.g., `parent.Name = otherEntity.Name` where both came back from the server with the same content but distinct string allocations. The setter treated this as a change, flipped `IsSelfModified = true` on the property, propagated `IsModified = true` on the entity, and emitted spurious MODIFY audit events.
+
+Deserialization itself was never the trigger: `EntityProperty<T>`'s `[JsonConstructor]` accepts `isSelfModified` directly from the wire. The bug only fired on the *next* setter write after deserialization.
+
+The method now delegates to `EqualityComparer<P>.Default.Equals`:
+
+```csharp
+protected virtual bool AreSame<P>(P? oldValue, P? newValue)
+{
+    if (oldValue == null && newValue == null) return true;
+    if (oldValue == null || newValue == null) return false;
+    return EqualityComparer<P>.Default.Equals(oldValue, newValue);
+}
+```
+
+This matches what `ValidateBase.RaiseIfChanged` (`src/Neatoo/ValidateBase.cs`) and `ValidateListBase` (`src/Neatoo/ValidateListBase.cs`) already use for cached-value comparison.
+
+Behavior changes:
+
+- **Strings and other reference types overriding `Equals` (or implementing `IEquatable<T>`)**: now compared by value. Equal-content writes correctly no-op.
+- **Child entity references** (`EntityBase`, `ValidateBase`, lists): unchanged. `EqualityComparer<T>.Default.Equals` falls back to `object.Equals`, which is reference equality for these types since they do not override `Equals`. Parent/child wiring in `HandleNonNullValue` continues to subscribe/unsubscribe correctly when child instances swap.
+- **Value types**: unchanged.
+
+Three regression tests cover the path:
+
+- `ValidatePropertyTests.AreSame_ContentEqualButDistinctStringInstance_TreatedAsSame` — asserts no `PropertyChanged(Value)` event when writing `new string("x".ToCharArray())` over `"x"`.
+- `EntityPropertyTests.IsSelfModified_AfterValueChangeToContentEqualButDistinctString_StaysUnmodified` — asserts the propagation through `EntityProperty`.
+- `FatClientEntityTests.FatClientEntity_StringAssignmentOfEqualValueFromSeparateDeserialization_DoesNotFlipIsModified` — full JSON round-trip with two independent deserializations and a mirror write across them.
+
+### Neatoo.RemoteFactory 1.1.0 → 1.6.1
+
+`Neatoo.RemoteFactory` and `Neatoo.RemoteFactory.AspNetCore` updated to `1.6.1` in `Directory.Packages.props`. No Neatoo source changes were required to compile or test against the new version.
+
+---
+
+## Related
+
+- [v0.30.1 - MudNeatooTextField UserAttributes null fix](v0.30.1.md)

--- a/src/Examples/Person/Person.DomainModel/Generated/Neatoo.Generator/Neatoo.Factory/DomainModel.PersonFactory.g.cs
+++ b/src/Examples/Person/Person.DomainModel/Generated/Neatoo.Generator/Neatoo.Factory/DomainModel.PersonFactory.g.cs
@@ -498,6 +498,11 @@ namespace DomainModel
             return Task.FromResult(CanSave(cancellationToken));
         }
 
+        Task<Authorized> IFactorySave<Person>.CanSave(Person target, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new Authorized(true));
+        }
+
         public virtual Authorized CanCreate(CancellationToken cancellationToken = default)
         {
             return LocalCanCreate(cancellationToken);
@@ -639,19 +644,7 @@ namespace DomainModel
                 return authorized;
             }
 
-            authorized = ipersonauth.HasAccess();
-            if (!authorized.HasAccess)
-            {
-                return authorized;
-            }
-
             authorized = ipersonauth.HasUpdate();
-            if (!authorized.HasAccess)
-            {
-                return authorized;
-            }
-
-            authorized = ipersonauth.HasAccess();
             if (!authorized.HasAccess)
             {
                 return authorized;
@@ -688,14 +681,6 @@ namespace DomainModel
                 var factory = cc.GetRequiredService<PersonFactory>();
                 return (IPerson target, CancellationToken cancellationToken = default) => factory.LocalSave(target, cancellationToken);
             });
-            // Event registrations
-            if (remoteLocal == NeatooFactory.Remote)
-            {
-            }
-
-            if (remoteLocal == NeatooFactory.Logical || remoteLocal == NeatooFactory.Server)
-            {
-            }
         }
     }
 }

--- a/src/Examples/Person/Person.DomainModel/Generated/Neatoo.Generator/Neatoo.Factory/DomainModel.PersonPhoneFactory.g.cs
+++ b/src/Examples/Person/Person.DomainModel/Generated/Neatoo.Generator/Neatoo.Factory/DomainModel.PersonPhoneFactory.g.cs
@@ -224,14 +224,6 @@ namespace DomainModel
             // DTO constructor registrations (IL trimming support)
             DtoConstructorRegistry.Register<global::Person.Dal.PersonPhoneEntity>(() => new global::Person.Dal.PersonPhoneEntity());
             DtoConstructorRegistry.Register<global::Person.Dal.PersonEntity>(() => new global::Person.Dal.PersonEntity());
-            // Event registrations
-            if (remoteLocal == NeatooFactory.Remote)
-            {
-            }
-
-            if (remoteLocal == NeatooFactory.Logical || remoteLocal == NeatooFactory.Server)
-            {
-            }
         }
     }
 }

--- a/src/Examples/Person/Person.DomainModel/Generated/Neatoo.Generator/Neatoo.Factory/DomainModel.PersonPhoneListFactory.g.cs
+++ b/src/Examples/Person/Person.DomainModel/Generated/Neatoo.Generator/Neatoo.Factory/DomainModel.PersonPhoneListFactory.g.cs
@@ -237,14 +237,6 @@ namespace DomainModel
                 var factory = cc.GetRequiredService<PersonPhoneListFactory>();
                 return (Guid personId, CancellationToken cancellationToken = default) => factory.LocalFetch1(personId, cancellationToken);
             });
-            // Event registrations
-            if (remoteLocal == NeatooFactory.Remote)
-            {
-            }
-
-            if (remoteLocal == NeatooFactory.Logical || remoteLocal == NeatooFactory.Server)
-            {
-            }
         }
     }
 }

--- a/src/Neatoo.UnitTest/Integration/Concepts/Serialization/FatClientEntityTests.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/Serialization/FatClientEntityTests.cs
@@ -126,6 +126,37 @@ public class FatClientEntityTests : IntegrationTestBase
     }
 
     [TestMethod]
+    public void FatClientEntity_StringAssignmentOfEqualValueFromSeparateDeserialization_DoesNotFlipIsModified()
+    {
+        // Regression: zTreatment reported spurious MODIFY audit events after a mirror write
+        // like `plan.ApprovedProtocol = recipe.Protocol`, where both strings were content-equal
+        // but came from independent JSON deserializations (distinct heap allocations). The
+        // property setter must compare strings by value, not by reference.
+        _target.MarkUnmodified();
+        var json = Serialize(_target);
+
+        // Two independent deserializations of the same payload -> two entities whose Name strings
+        // are content-equal but distinct instances. This mirrors the zTreatment Open->client->Save
+        // round-trip allocation pattern.
+        var targetA = DeserializeEntity(json);
+        var targetB = DeserializeEntity(json);
+
+        Assert.IsFalse(targetA.IsModified, "Baseline: deserialized targetA should not be modified.");
+        Assert.AreEqual(targetA.Name, targetB.Name, "Sanity: Names must be content-equal across the two deserializations.");
+        Assert.IsFalse(ReferenceEquals(targetA.Name, targetB.Name),
+            "Sanity: the two Names must be distinct instances for this regression to be exercised. " +
+            "If this fails, the JSON pipeline is interning strings and the bug cannot reproduce here.");
+
+        // Mirror write: equal content, distinct instance.
+        targetA.Name = targetB.Name;
+
+        Assert.IsFalse(targetA.IsSelfModified,
+            "IsSelfModified must not flip when mirror-writing a content-equal string from a separately deserialized entity.");
+        Assert.IsFalse(targetA.IsModified,
+            "IsModified must not flip when mirror-writing a content-equal string from a separately deserialized entity.");
+    }
+
+    [TestMethod]
     public void FatClientEntity_IsNew()
     {
 

--- a/src/Neatoo.UnitTest/Unit/Core/EntityPropertyTests.cs
+++ b/src/Neatoo.UnitTest/Unit/Core/EntityPropertyTests.cs
@@ -237,6 +237,27 @@ public class EntityPropertyTests
     }
 
     [TestMethod]
+    public void IsSelfModified_AfterValueChangeToContentEqualButDistinctString_StaysUnmodified()
+    {
+        // Regression: the sibling test above passes only because the C# compiler interns string
+        // literals, so both writes share the same reference. When the new string is content-equal
+        // but a distinct allocation (as happens with strings produced by JSON deserialization),
+        // IsSelfModified must still stay false. Real-world trigger: mirror writes between two
+        // entities deserialized from separate payloads.
+        var wrapper = CreatePropertyInfoWrapper("Name");
+        var property = new EntityProperty<string>(wrapper);
+        property.Value = "InitialValue";
+        property.MarkSelfUnmodified();
+
+        property.Value = new string("InitialValue".ToCharArray());
+
+        Assert.IsFalse(property.IsSelfModified,
+            "IsSelfModified must not flip when the new string is content-equal but a distinct instance.");
+        Assert.IsFalse(property.IsModified,
+            "IsModified must not flip when the new string is content-equal but a distinct instance.");
+    }
+
+    [TestMethod]
     public void IsSelfModified_AfterValueChangeToDifferentValue_ReturnsTrue()
     {
         // Arrange

--- a/src/Neatoo.UnitTest/Unit/Core/ValidatePropertyTests.cs
+++ b/src/Neatoo.UnitTest/Unit/Core/ValidatePropertyTests.cs
@@ -1111,6 +1111,30 @@ public class ValidatePropertyTests
     }
 
     [TestMethod]
+    public void AreSame_ContentEqualButDistinctStringInstance_TreatedAsSame()
+    {
+        // Regression: equal-content strings from separate allocations (e.g., post-JSON-deserialization
+        // mirror writes between entities) must NOT be treated as a change. ReferenceEquals returns
+        // false for distinct instances; value equality should be used for strings.
+        var wrapper = CreatePropertyInfoWrapper<string>("Name");
+        var property = new ValidateProperty<string>(wrapper);
+        property.Value = "pn:initial:10";
+
+        var eventRaised = false;
+        property.PropertyChanged += (sender, e) =>
+        {
+            if (e.PropertyName == "Value")
+                eventRaised = true;
+        };
+
+        // new string(char[]) guarantees a distinct heap allocation, bypassing string interning
+        property.Value = new string("pn:initial:10".ToCharArray());
+
+        Assert.IsFalse(eventRaised,
+            "PropertyChanged for Value must not fire when the new string equals the existing value, even if it is a distinct instance.");
+    }
+
+    [TestMethod]
     public void IsReadOnly_InheritedFromPropertyInfo()
     {
         // Arrange - using a property with private setter

--- a/src/Neatoo/Internal/ValidateProperty.cs
+++ b/src/Neatoo/Internal/ValidateProperty.cs
@@ -348,6 +348,12 @@ public class ValidateProperty<T> : IValidateProperty<T>, IValidatePropertyIntern
 
     protected virtual bool AreSame<P>(P? oldValue, P? newValue)
     {
+        // Use value equality (via EqualityComparer<P>.Default) so reference types that override
+        // Equals -- string, decimal-as-reference, any IEquatable<T> -- are compared by value.
+        // For reference types without an Equals override (e.g. EntityBase/ValidateBase children),
+        // EqualityComparer<T>.Default falls back to object.Equals -> reference equality, preserving
+        // the prior behavior. The leading null guard mirrors the original method shape and avoids
+        // any difference in how EqualityComparer handles two nulls vs. one-null comparisons.
         if (oldValue == null && newValue == null)
         {
             return true;
@@ -357,14 +363,7 @@ public class ValidateProperty<T> : IValidateProperty<T>, IValidatePropertyIntern
             return false;
         }
 
-        if (!typeof(P).IsValueType)
-        {
-            return (ReferenceEquals(oldValue, newValue));
-        }
-        else
-        {
-            return oldValue.Equals(newValue);
-        }
+        return EqualityComparer<P>.Default.Equals(oldValue, newValue);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
## Summary

- **Bug fix.** `ValidateProperty<T>.AreSame<P>` now uses `EqualityComparer<P>.Default.Equals` instead of `ReferenceEquals` for reference-type comparisons. Equal-content but distinct string instances (typically allocated by JSON deserialization) no longer flip `IsSelfModified` / `IsModified` when written via the property setter. Real-world trigger: post-round-trip mirror writes across two entities deserialized from independent payloads.
- **Dependency.** `Neatoo.RemoteFactory` and `Neatoo.RemoteFactory.AspNetCore` bumped `1.1.0` → `1.6.1`. The Person example's generated factory files were regenerated by the new generator (added `CanSave(target, ct)` interface implementation; removed redundant `HasAccess()` calls and empty event-registration scaffolding).
- **Version.** `0.30.2`. Release notes added at `docs/release-notes/v0.30.2.md`.

Child-entity references (`EntityBase`, `ValidateBase`, lists) are unchanged — `EqualityComparer<T>.Default` falls back to `object.Equals` (reference equality) for types that don't override `Equals`. This matches what `ValidateBase.RaiseIfChanged` and `ValidateListBase` already use for cached-value comparison.

## Test plan

- [x] Three regression tests added, all FAIL on `main` and PASS after the fix:
  - `ValidatePropertyTests.AreSame_ContentEqualButDistinctStringInstance_TreatedAsSame` — asserts no `PropertyChanged(Value)` fires.
  - `EntityPropertyTests.IsSelfModified_AfterValueChangeToContentEqualButDistinctString_StaysUnmodified` — asserts propagation through `EntityProperty`.
  - `FatClientEntityTests.FatClientEntity_StringAssignmentOfEqualValueFromSeparateDeserialization_DoesNotFlipIsModified` — two independent JSON deserializations + mirror write across them (reproduces the production scenario).
- [x] Full suite green against RemoteFactory 1.6.1: **2251 passed, 2 pre-existing skips, 0 failed** (Neatoo.UnitTest 1796, Samples 254, Person.DomainModel.Tests 55, Neatoo.BaseGenerator.Tests 42, Design.Tests 104).
- [x] Compiled `Neatoo.dll` reports assembly version `0.30.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)