### PR TITLE
Remove the IsChild flag

### DIFF
--- a/.claude/agents/business-requirements-reviewer.md
+++ b/.claude/agents/business-requirements-reviewer.md
@@ -199,7 +199,7 @@ The most dangerous contradictions in a framework are implicit. Watch for:
 - **Serialization round-trip** — What survives JSON serialization between client and server. Changes to property storage affect client-server state transfer.
 - **Source generator output** — Changes to base classes affect what BaseGenerator and RemoteFactory generate. A change in ValidateBase may break generated code for every entity.
 - **Rule execution timing** — When rules fire relative to property changes and factory operations. Changes to timing affect validation behavior across all entities.
-- **Parent-child relationships** — IsChild, Root, Parent, ContainingList references. Changes to how these are set affect aggregate boundary enforcement.
+- **Parent-child relationships** — Root, Parent, ContainingList references. Changes to how these are set affect aggregate boundary enforcement.
 
 ### Step 4: Write Findings into Todo
 

--- a/.claude/agents/neatoo-developer.md
+++ b/.claude/agents/neatoo-developer.md
@@ -469,7 +469,7 @@ These are common issues in Neatoo plans. Check for each:
 2. **Factory operation lifecycle impacts?** Does the change affect [Create], [Fetch], [Insert], [Update], [Delete], [Execute] behavior?
 3. **Property system impacts?** Getter/Setter, change tracking, LoadValue vs SetValue
 4. **Validation rule interactions?** RuleManager, AddValidation, AddAction, async rules, rule triggers
-5. **Parent-child relationships?** IsChild, Parent, Root, ContainingList, aggregate boundary enforcement
+5. **Parent-child relationships?** Parent, Root, ContainingList, aggregate boundary enforcement
 6. **Serialization/state transfer?** Client-server boundary, what survives JSON round-trip, $id/$ref handling
 7. **RemoteFactory source generation impacts?** Factory interface generation, [Remote] attribute, HTTP proxies
 8. **State property consistency?** IsModified, IsNew, IsValid, IsBusy, IsPaused, IsDeleted, IsSavable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ public interface IOrder : IEntityRoot { ... }
 public interface IOrderLine : IEntityBase { ... }
 ```
 
-**Why this exists:** `IsSavable` on `EntityBase` includes a `!IsChild` check, making it always false for child entities. Developers naturally used `IsSavable` in save cascade logic to check whether children need persisting -- but it silently returned false, skipping saves (real bug in zTreatment). The fix is not to make `IsSavable` work on children -- it is to remove it from the child interface entirely. Child entity factory methods (`[Insert]`/`[Update]`) have signatures that outside consumers cannot fulfill (they often need the parent entity or parent ID), and entity classes are `internal`, so external callers should not be able to save children at all.
+**Why this exists:** `EntityBase` defines `IsSavable` (`IsModified && IsValid && !IsBusy`) and `Save()` as concrete members, so a modified child *concrete* looks savable -- but children are persisted by their aggregate root, never on their own. Exposing `IsSavable`/`Save()` on a child interface is misleading: developers naturally use `IsSavable` in save cascade logic and try to call `Save()` on a child, which the framework does not support (real bug in zTreatment, where `IsSavable` was used to decide whether children needed persisting). The fix is to keep `IsSavable`/`Save()` off the child interface entirely. Child entity factory methods (`[Insert]`/`[Update]`) have signatures that outside consumers cannot fulfill (they often need the parent entity or parent ID), and entity classes are `internal`, so external callers cannot save children at all.
 
 ### State Properties
 - `IsModified` - True when object has unsaved changes
@@ -98,7 +98,7 @@ public interface IOrderLine : IEntityBase { ... }
 - `IsNew` - True when object hasn't been persisted yet
 - `IsValid` - True when all validation rules pass
 - `IsSelfValid` - True when this object's rules pass (not children)
-- `IsSavable` - True when entity can be saved (IsModified && IsValid && !IsBusy && !IsChild). **Only on `IEntityRoot`** -- not on `IEntityBase` or `IEntityListBase`. Child entities and entity lists never expose this property through their interfaces.
+- `IsSavable` - True when entity can be saved (IsModified && IsValid && !IsBusy). **Only on `IEntityRoot`** -- not on `IEntityBase` or `IEntityListBase`. Child entities and entity lists never expose this property through their interfaces.
 
 ### Factory Operations
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Package Metadata -->
 		<Authors>Keith Voels</Authors>
 		<Copyright>Copyright © 2025</Copyright>
-		<Version>0.30.2</Version>
+		<Version>0.31.0</Version>
 
 		<!-- NuGet Security Auditing -->
 		<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,7 +186,7 @@ Entity state tracking properties:
 - `IsNew` - True for newly created entities that have not been persisted
 - `IsModified` - True if any property has changed since load/save (cascades from children)
 - `IsDeleted` - True if marked for deletion
-- `IsSavable` - Computed property: true if `IsModified && IsValid && !IsBusy && !IsChild`. Only accessible through the `IEntityRoot` interface (aggregate roots), not `IEntityBase` (child entities)
+- `IsSavable` - Computed property: true if `IsModified && IsValid && !IsBusy`. Only accessible through the `IEntityRoot` interface (aggregate roots), not `IEntityBase` (child entities)
 
 The `[Fetch]` attribute marks a data access method. RemoteFactory generates a factory interface (`IEmployeeEntityFactory`) with a corresponding `FetchAsync(int id)` method that resolves the repository from DI and calls your method. The `[Service]` attribute indicates the parameter should be injected from the service provider.
 

--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -431,7 +431,7 @@ public async Task Save_WaitsForAsyncValidation()
 <sup><a href='/src/samples/AsyncSamples.cs#L532-L551' title='Snippet source file'>snippet source</a> | <a href='#snippet-async-save-entity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-If async rules are still executing (`IsBusy == true`) or the entity is invalid (`IsValid == false`) after `WaitForTasks`, the factory does not call your persistence method. Instead, it relies on `IsSavable` (available on aggregate root entities via the `IEntityRoot` interface) to determine if persistence should proceed. Since `IsSavable == IsModified && IsValid && !IsBusy && !IsChild`, an invalid or busy entity cannot be saved.
+If async rules are still executing (`IsBusy == true`) or the entity is invalid (`IsValid == false`) after `WaitForTasks`, the factory does not call your persistence method. Instead, it relies on `IsSavable` (available on aggregate root entities via the `IEntityRoot` interface) to determine if persistence should proceed. Since `IsSavable == IsModified && IsValid && !IsBusy`, an invalid or busy entity cannot be saved.
 
 ## Performance Considerations
 

--- a/docs/guides/change-tracking.md
+++ b/docs/guides/change-tracking.md
@@ -350,9 +350,8 @@ An entity is savable when all of the following are true:
 - `IsModified` - The entity has changes requiring persistence
 - `IsValid` - All validation rules pass
 - `!IsBusy` - No async operations are in progress
-- `!IsChild` - The entity is not a child (child entities save through their parent)
 
-**Why IsSavable is IEntityRoot only:** `IsSavable` on `EntityBase` includes a `!IsChild` check, making it always false for child entities. Developers naturally used `IsSavable` in save cascade logic to check whether children need persisting, but it silently returned false, skipping saves. This caused a real production bug. The fix removes `IsSavable` from the child interface entirely. Aggregate root interfaces extend `IEntityRoot`; child entity interfaces extend `IEntityBase`.
+**Why IsSavable is IEntityRoot only:** `EntityBase` defines `IsSavable` (`IsModified && IsValid && !IsBusy`) and `Save()` as concrete members, so a modified child *concrete* looks savable -- but children are persisted by their aggregate root, never on their own. Exposing `IsSavable`/`Save()` on a child interface is misleading: developers naturally use `IsSavable` in save-cascade logic and try to call `Save()` on a child, which the framework does not support (a real production bug in zTreatment). The fix is to keep `IsSavable`/`Save()` off the child interface entirely. Aggregate root interfaces extend `IEntityRoot`; child entity interfaces extend `IEntityBase`.
 
 This architecture ensures child entities within an aggregate cannot be saved independently, maintaining aggregate consistency:
 
@@ -372,15 +371,14 @@ public void IsSavable_CombinesModificationAndValidation()
     // Modify the entity
     employee.Name = "Bob";
 
-    // Modified, valid, not busy, not child = savable
+    // Modified, valid, not busy = savable
     Assert.True(employee.IsModified);
     Assert.True(employee.IsValid);
     Assert.False(employee.IsBusy);
-    Assert.False(employee.IsChild);
     Assert.True(employee.IsSavable);
 }
 ```
-<sup><a href='/src/samples/ChangeTrackingSamples.cs#L354-L375' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-is-savable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ChangeTrackingSamples.cs#L354-L374' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-is-savable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `Save()` method checks `IsSavable` and throws `SaveOperationException` with a specific reason code if the preconditions are not met:
@@ -405,11 +403,10 @@ public async Task Save_ThrowsWithSpecificReason()
     Assert.Equal(SaveFailureReason.NotModified, exception.Reason);
 }
 ```
-<sup><a href='/src/samples/ChangeTrackingSamples.cs#L377-L394' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-save-checks' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ChangeTrackingSamples.cs#L376-L393' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-save-checks' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Common `SaveFailureReason` values:
-- `IsChildObject` - Entity is a child and must be saved through its parent
 - `IsInvalid` - Validation rules have failed
 - `NotModified` - No changes detected (nothing to persist)
 - `IsBusy` - Async operations still in progress
@@ -447,7 +444,7 @@ public void PauseAllActions_PreventsModificationTracking()
     Assert.Empty(employee.ModifiedProperties);
 }
 ```
-<sup><a href='/src/samples/ChangeTrackingSamples.cs#L396-L419' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-pause-actions' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ChangeTrackingSamples.cs#L395-L418' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-pause-actions' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 While paused, property setters still execute but tracking mechanisms are disabled:
@@ -487,7 +484,7 @@ public void IsNew_IndicatesUnpersistedEntity()
     Assert.True(employee.IsModified);
 }
 ```
-<sup><a href='/src/samples/ChangeTrackingSamples.cs#L421-L434' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-is-new' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ChangeTrackingSamples.cs#L420-L433' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-is-new' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `IsNew` flag is automatically set by factory Create methods and cleared after successful Insert. New entities are always considered modified (`IsNew` contributes to `IsModified`).
@@ -520,7 +517,7 @@ public void IsDeleted_MarksEntityForDeletion()
     Assert.False(employee.IsModified);
 }
 ```
-<sup><a href='/src/samples/ChangeTrackingSamples.cs#L436-L459' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-is-deleted' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ChangeTrackingSamples.cs#L435-L458' title='Snippet source file'>snippet source</a> | <a href='#snippet-tracking-is-deleted' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `IsDeleted` flag is set by calling `Delete()` and can be reversed with `UnDelete()` before saving. Deleted entities contribute to both `IsModified` and `IsSelfModified`, ensuring they are recognized as changed and savable.

--- a/docs/guides/collections.md
+++ b/docs/guides/collections.md
@@ -99,7 +99,7 @@ EntityListBase additionally enforces aggregate boundary rules:
 - Prevents adding busy items (with async validation rules running)
 - Prevents cross-aggregate moves (item.Root must match list.Root or be null)
 - Marks existing entities as modified (they're being re-added to the graph)
-- Marks items as child entities (IsChild = true)
+- Adds items to the aggregate (the item's `Root` points to the aggregate root)
 - Sets the item's ContainingList property (tracks which collection owns the entity)
 - Handles intra-aggregate moves (removes from old list's DeletedList, undeletes item)
 

--- a/docs/guides/entities.md
+++ b/docs/guides/entities.md
@@ -20,7 +20,7 @@ EntityBase adds:
 - Modification tracking (IsModified, IsSelfModified, ModifiedProperties)
 - Persistence state (IsNew, IsDeleted)
 - Save operations (Save, Delete) -- `Save()` and `IsSavable` accessible through `IEntityRoot` (aggregate roots only)
-- Aggregate patterns (Root, IsChild)
+- Aggregate patterns (Root)
 - Factory integration for Insert/Update/Delete
 
 Inherit from EntityBase when the object requires persistence:
@@ -64,7 +64,7 @@ public interface IOrder : IEntityRoot { ... }
 public interface IOrderLine : IEntityBase { ... }
 ```
 
-**Why this design exists:** `IsSavable` on `EntityBase` includes a `!IsChild` check, making it always false for child entities. Developers naturally used `IsSavable` in save cascade logic to check whether children need persisting — but it silently returned false, skipping saves. This caused a real production bug. The fix is not to make `IsSavable` work on children — it is to remove it from the child interface entirely. Child entity factory methods (`[Insert]`/`[Update]`) have signatures that outside consumers cannot fulfill (they often need the parent entity or parent ID), and entity classes are `internal`, so external callers should not be saving children at all.
+**Why this design exists:** `EntityBase` defines `IsSavable` (`IsModified && IsValid && !IsBusy`) and `Save()` as concrete members, so a modified child *concrete* looks savable — but children are persisted by their aggregate root, never on their own. Exposing `IsSavable`/`Save()` on a child interface is misleading: developers naturally use `IsSavable` in save-cascade logic and try to call `Save()` on a child, which the framework does not support (a real production bug in zTreatment). The fix is to keep `IsSavable`/`Save()` off the child interface entirely. Aggregate root interfaces extend `IEntityRoot`; child entity interfaces extend `IEntityBase`. Child entity factory methods (`[Insert]`/`[Update]`) have signatures that outside consumers cannot fulfill (they often need the parent entity or parent ID), and entity classes are `internal`, so external callers should not be saving children at all.
 
 The concrete `EntityBase<T>` implements both `IEntityBase` and `IEntityRoot`, so it retains `IsSavable` and `Save()` as concrete members. This does not matter because entity classes should be `internal` — consumers interact through the public interface, which is the access control mechanism.
 
@@ -115,14 +115,12 @@ public partial class EntitiesOrder : EntityBase<EntitiesOrder>
 <!-- endSnippet -->
 
 Aggregate roots:
-- Have `IsChild == false`
 - Can call `Save()` directly
 - Have `Root == null` (they are the root)
 - Coordinate saving child entities
 
 Child entities within the aggregate:
-- Have `IsChild == true`
-- Cannot call `Save()` directly (throws SaveOperationException)
+- Cannot call `Save()` directly -- `IEntityBase` (the child interface) has no `Save()`
 - Have `Root` pointing to the aggregate root
 - Are saved through the parent's save operation
 
@@ -276,7 +274,6 @@ Save only succeeds when:
 - `IsValid == true`
 - `IsModified == true`
 - `IsBusy == false`
-- `IsChild == false`
 
 After successful Insert or Update:
 - `IsModified == false`
@@ -558,7 +555,7 @@ State transitions:
 
 Neatoo is a DDD framework designed for data-binding UIs. `IsSavable` is meant to be bound directly to a Save button's `Enabled` state — the framework manages the conditions, and the UI automatically reflects whether saving is possible right now. No conditional logic needed in the view.
 
-`IsSavable` is exposed through `IEntityRoot` (the aggregate root interface), not `IEntityBase` (the child entity interface). This is deliberate — `IsSavable` includes a `!IsChild` check, so it was always false on child entities. Removing it from the child interface prevents the trap of using `IsSavable` in save cascade logic, where it would silently return false and skip persistence.
+`IsSavable` is exposed through `IEntityRoot` (the aggregate root interface), not `IEntityBase` (the child entity interface). This is deliberate — `EntityBase` defines `IsSavable` (`IsModified && IsValid && !IsBusy`) and `Save()` as concrete members, so a modified child *concrete* looks savable, but children are persisted by their aggregate root, never on their own. Removing these members from the child interface prevents the trap of using `IsSavable` in save cascade logic or calling `Save()` on a child, which the framework does not support (a real production bug in zTreatment).
 
 <!-- snippet: entities-savable -->
 <a id='snippet-entities-savable'></a>
@@ -582,18 +579,16 @@ public void IsSavable_CombinesStateChecks()
     Assert.True(order.IsModified);    // Something changed
     Assert.True(order.IsValid);       // Passes validation
     Assert.False(order.IsBusy);       // No async operations
-    Assert.False(order.IsChild);      // Not a child entity
     Assert.True(order.IsSavable);     // Can save!
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L631-L654' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L631-L653' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 IsSavable is true when:
 - `IsModified == true` (something changed)
 - `IsValid == true` (passes validation)
 - `IsBusy == false` (no async operations running)
-- `IsChild == false` (not a child entity)
 
 `IsSavable` and `Save()` are only accessible through the `IEntityRoot` interface. Child entity interfaces extend `IEntityBase`, which does not include these members. Children must be saved through the aggregate root.
 
@@ -618,11 +613,10 @@ public void ChildEntity_CannotSaveDirectly()
     item.Price = 29.99m;
     item.Quantity = 1;
 
-    // Add to collection marks entity as child
+    // Add to collection (the item becomes part of the aggregate)
     order.Items.Add(item);
 
-    // Child entity state
-    Assert.True(item.IsChild);
+    // Child entity is reachable through its aggregate root
     Assert.Same(order, item.Root);
 
     // Child interfaces (IEntityBase) don't expose IsSavable or Save().
@@ -630,13 +624,13 @@ public void ChildEntity_CannotSaveDirectly()
     // This is enforced at the type level — no runtime check needed.
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L656-L682' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L655-L680' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Child entities:
-- Are marked as children when added to EntityListBase
+- Join the aggregate when added to EntityListBase (their `Root` points to the aggregate root)
 - Their interfaces extend `IEntityBase` (not `IEntityRoot`), so `IsSavable` and `Save()` are not accessible to consumers
-- If `Save()` is somehow called on the concrete class, it throws `SaveOperationException` with `SaveFailureReason.IsChildObject`
+- Calling `Save()` on a child does not compile -- `IEntityBase` (the child interface) has no `Save()`
 - Have ContainingList set to the owning collection
 - Are saved through the aggregate root's save operation
 
@@ -720,7 +714,7 @@ public void Factory_SetThroughDependencyInjection()
     // The factory calls Insert, Update, or Delete based on entity state
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L684-L699' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L682-L697' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 After each factory operation, the framework automatically updates entity state — setting `IsNew`, clearing modification tracking — so the lifecycle stays in sync with persistence without manual intervention.
@@ -752,7 +746,7 @@ public async Task Save_SupportsCancellation()
     Assert.True(order.IsModified);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L701-L721' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L699-L719' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Cancellation behavior:

--- a/docs/guides/parent-child.md
+++ b/docs/guides/parent-child.md
@@ -136,21 +136,15 @@ public void AggregateBoundary_EnforcedByParentProperty()
     // Child entity: Parent set, Root points to aggregate root
     Assert.Same(order, lineItem.Parent);
     Assert.Same(order, lineItem.Root);
-
-    // Child is marked as child entity
-    Assert.True(lineItem.IsChild);
-
-    // Aggregate root is not a child
-    Assert.False(order.IsChild);
 }
 ```
-<sup><a href='/src/samples/ParentChildSamples.cs#L193-L227' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-aggregate-boundary' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ParentChildSamples.cs#L193-L221' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-aggregate-boundary' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Aggregate boundary rules:
 - Aggregate roots have Parent == null and Root == null
 - Child entities have Parent set and Root pointing to the aggregate root
-- Child entities cannot be saved independently (IsChild == true)
+- Child entities cannot be saved independently -- their interface (`IEntityBase`) has no `Save()`
 - Crossing aggregate boundaries requires explicit relationship management
 - Parent changes are restricted to prevent cross-aggregate contamination
 
@@ -202,7 +196,7 @@ public async Task CascadeValidation_ChildInvalidMakesParentInvalid()
     Assert.True(order.IsValid);
 }
 ```
-<sup><a href='/src/samples/ParentChildSamples.cs#L229-L266' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-cascade-validation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ParentChildSamples.cs#L223-L260' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-cascade-validation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Cascade behavior:
@@ -250,7 +244,7 @@ public void CascadeDirty_ChildModificationCascadesToParent()
     Assert.True(item.IsModified);
 }
 ```
-<sup><a href='/src/samples/ParentChildSamples.cs#L268-L295' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-cascade-dirty' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ParentChildSamples.cs#L262-L289' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-cascade-dirty' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Cascade rules for IsModified:
@@ -286,36 +280,32 @@ public void ChildLifecycle_MarkedWhenAddedToCollection()
     item.UnitPrice = 99.99m;
     item.Quantity = 1;
 
-    // Before adding: not a child
-    Assert.False(item.IsChild);
+    // Before adding: standalone entity with no aggregate root
     Assert.Null(item.Root);
 
     // Add to collection
     order.LineItems.Add(item);
 
     // After adding:
-    // 1. IsChild is set to true
-    Assert.True(item.IsChild);
-
-    // 2. Root points to aggregate root
+    // 1. Root points to aggregate root
     Assert.Same(order, item.Root);
 
-    // 3. Parent is set
+    // 2. Parent is set
     Assert.Same(order, item.Parent);
 
-    // 4. Child interfaces (IEntityBase) don't expose IsSavable or Save().
+    // 3. Child interfaces (IEntityBase) don't expose IsSavable or Save().
     //    Only IEntityRoot exposes those members.
     //    This is enforced at the type level — no runtime check needed.
 }
 ```
-<sup><a href='/src/samples/ParentChildSamples.cs#L297-L333' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-lifecycle' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ParentChildSamples.cs#L291-L323' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-lifecycle' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Child entity restrictions:
 - `IEntityBase` (the child entity interface) does not expose `IsSavable` or `Save()` -- these are on `IEntityRoot` only
-- If a caller somehow accesses `Save()` on the concrete class, it throws `SaveOperationException` with `SaveFailureReason.IsChildObject`
+- Calling `Save()` on a child does not compile -- `IEntityBase` (the child interface) has no `Save()`
 - Must be saved through the aggregate root
-- Marked as `IsChild` when added to a collection
+- Added to the aggregate when placed in a collection (its `Root` points to the aggregate root)
 - Cannot be added to a different aggregate while already belonging to one
 
 This restriction is enforced at the type level. Child entity interfaces extend `IEntityBase`, so `IsSavable` and `Save()` simply do not exist on the interface. No runtime check needed for well-typed code.
@@ -323,10 +313,9 @@ This restriction is enforced at the type level. Child entity interfaces extend `
 When a child entity is added to a collection:
 1. Parent is set to the collection's Parent (the owning entity)
 2. Root is recalculated from Parent (recursively to aggregate root)
-3. IsChild is set to true
-4. ContainingList is set to the collection
-5. Validation and modification state cascade to parent
-6. Cross-aggregate validation ensures Root compatibility
+3. ContainingList is set to the collection
+4. Validation and modification state cascade to parent
+5. Cross-aggregate validation ensures Root compatibility
 
 ## Collection Navigation
 
@@ -376,7 +365,7 @@ public void CollectionNavigation_AccessSiblingsThroughParent()
     Assert.Equal(50.00m, total); // (10*1) + (20*2)
 }
 ```
-<sup><a href='/src/samples/ParentChildSamples.cs#L335-L374' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-containing-list' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ParentChildSamples.cs#L325-L364' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-containing-list' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Navigation patterns:
@@ -429,7 +418,7 @@ public void RootAccess_FromChildEntity()
     Assert.Equal(new DateTime(2024, 6, 15), orderRoot.OrderDate);
 }
 ```
-<sup><a href='/src/samples/ParentChildSamples.cs#L376-L406' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-root-access' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ParentChildSamples.cs#L366-L396' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-root-access' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Root access patterns:
@@ -506,7 +495,7 @@ public void CollectionParent_AutomaticManagement()
     Assert.Same(order, item2.Root);
 }
 ```
-<sup><a href='/src/samples/ParentChildSamples.cs#L408-L442' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-collection-parent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ParentChildSamples.cs#L398-L432' title='Snippet source file'>snippet source</a> | <a href='#snippet-parent-child-collection-parent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Collection parent propagation:

--- a/docs/guides/remote-factory.md
+++ b/docs/guides/remote-factory.md
@@ -80,14 +80,13 @@ Before save executes, check `IsSavable` (available on aggregate roots through `I
 /// </summary>
 public static async Task<bool> CheckSavableBeforeSave(SkillRfIntegrationRoot entity)
 {
-    // IsSavable = IsModified && IsValid && !IsBusy && !IsChild
+    // IsSavable = IsModified && IsValid && !IsBusy
     if (!entity.IsSavable)
     {
         // Don't persist - one or more conditions failed:
         // - !IsModified: No changes to save
         // - !IsValid: Validation failed
         // - IsBusy: Async rules still running
-        // - IsChild: Must save through parent aggregate
         return false;
     }
 
@@ -95,7 +94,7 @@ public static async Task<bool> CheckSavableBeforeSave(SkillRfIntegrationRoot ent
     return true;
 }
 ```
-<sup><a href='/src/samples/RemoteFactoryIntegrationSamples.cs#L179-L199' title='Snippet source file'>snippet source</a> | <a href='#snippet-remote-factory-issavable-check' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/RemoteFactoryIntegrationSamples.cs#L179-L198' title='Snippet source file'>snippet source</a> | <a href='#snippet-remote-factory-issavable-check' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 After `[Insert]` or `[Update]` completes:
@@ -112,7 +111,7 @@ Child entities within an aggregate have their state cascade to the parent:
 | `IsValid = false` | Parent `IsValid = false` |
 | `IsBusy = true` | Parent `IsBusy = true` |
 
-Child entities have `IsChild = true` and must save through the aggregate root. Their interfaces extend `IEntityBase` (not `IEntityRoot`), so `IsSavable` and `Save()` are not accessible to consumers.
+Child entities are persisted through the aggregate root. Their interfaces extend `IEntityBase` (not `IEntityRoot`), so `IsSavable` and `Save()` are not accessible to consumers.
 
 <!-- snippet: remote-factory-child-no-remote -->
 <a id='snippet-remote-factory-child-no-remote'></a>
@@ -121,8 +120,8 @@ Child entities have `IsChild = true` and must save through the aggregate root. T
 [Create]
 public void Create()
 {
-    // IsChild = true (set when added to parent collection)
-    // IsSavable/Save() not accessible on IEntityBase (child interface)
+    // IsSavable/Save() not accessible on IEntityBase (child interface) —
+    // children persist through the aggregate root, never on their own
 }
 
 [Fetch]
@@ -183,7 +182,7 @@ public static void DeletedListLifecycle(
     // Step 4: After Save(), DeletedList is cleared
 }
 ```
-<sup><a href='/src/samples/RemoteFactoryIntegrationSamples.cs#L224-L247' title='Snippet source file'>snippet source</a> | <a href='#snippet-remote-factory-deletedlist-lifecycle' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/RemoteFactoryIntegrationSamples.cs#L223-L246' title='Snippet source file'>snippet source</a> | <a href='#snippet-remote-factory-deletedlist-lifecycle' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Serialization State Transfer
@@ -196,7 +195,6 @@ When entities cross client-server boundaries:
 | `IsNew` | Yes | Preserved across boundary |
 | `IsDeleted` | Yes | Preserved across boundary |
 | `IsModified` | Yes | Preserved across boundary |
-| `IsChild` | Yes | Preserved across boundary |
 | `DeletedList` items | Yes | For pending deletes |
 | Validation messages | No | Rules re-run after deserialization |
 | `IsBusy` | No | Reset on deserialization |

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -585,13 +585,13 @@ Meta-property definitions:
 - **IsSelfValid**: True if this object's properties pass validation (ignores children)
 - **IsBusy**: True if any async validation tasks are running
 - **PropertyMessages**: Collection of ALL validation messages (this object + children)
-- **IsSavable**: (`IEntityRoot` only) True if IsModified && IsValid && !IsBusy && !IsChild. Not available on `IEntityBase` (child entity interface) or entity lists
+- **IsSavable**: (`IEntityRoot` only) True if IsModified && IsValid && !IsBusy. Not available on `IEntityBase` (child entity interface) or entity lists
 
 Meta-properties fire PropertyChanged events when their values change, enabling UI binding for save button enablement and validation indicators.
 
 ## Validation During Save
 
-Validate entities before persisting changes. The `IsSavable` property (accessible through `IEntityRoot`, the aggregate root interface) combines `IsModified`, `IsValid`, `IsBusy`, and `IsChild` to determine if the entity can be saved. Child entity interfaces (`IEntityBase`) do not expose `IsSavable`.
+Validate entities before persisting changes. The `IsSavable` property (accessible through `IEntityRoot`, the aggregate root interface) combines `IsModified`, `IsValid`, and `IsBusy` to determine if the entity can be saved. Child entity interfaces (`IEntityBase`) do not expose `IsSavable`.
 
 Validate before save:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -416,12 +416,10 @@ Accepts entity services containing property manager, rule manager factory, and s
 ```csharp
 public virtual bool IsNew { get; protected set; }
 public virtual bool IsDeleted { get; protected set; }
-public virtual bool IsChild { get; protected set; }
 ```
 
 - **IsNew**: Entity has not been persisted (Insert operation on save)
 - **IsDeleted**: Entity marked for deletion (Delete operation on save)
-- **IsChild**: Entity is part of an aggregate and cannot be saved independently
 
 <!-- snippet: api-entitybase-persistence-state -->
 <a id='snippet-api-entitybase-persistence-state'></a>
@@ -435,7 +433,6 @@ public void PersistenceState_TracksEntityLifecycle()
     var newEmployee = factory.Create();
     Assert.True(newEmployee.IsNew);   // New entity - will Insert on save
     Assert.False(newEmployee.IsDeleted);
-    Assert.False(newEmployee.IsChild);
 
     // Fetch existing entity
     var existingEmployee = factory.Fetch(1, "Alice", "Engineering");
@@ -446,7 +443,7 @@ public void PersistenceState_TracksEntityLifecycle()
     Assert.True(existingEmployee.IsDeleted);  // Will Delete on save
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L875-L895' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-persistence-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L875-L894' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-persistence-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Modification Tracking
@@ -486,7 +483,7 @@ public void ModificationTracking_DetectsChanges()
     Assert.Contains("Name", employee.ModifiedProperties);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L897-L917' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-modification' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L896-L916' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-modification' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Savability
@@ -495,7 +492,7 @@ public void ModificationTracking_DetectsChanges()
 public virtual bool IsSavable { get; }
 ```
 
-Entity can be saved when: `IsModified && IsValid && !IsBusy && !IsChild`
+Entity can be saved when: `IsModified && IsValid && !IsBusy`
 
 `IsSavable` exists on the concrete `EntityBase<T>` class, but is only exposed through the `IEntityRoot` interface -- not through `IEntityBase`. This means child entities (whose interfaces extend `IEntityBase`) never expose `IsSavable` to consumers. Aggregate root interfaces extend `IEntityRoot`, which adds `IsSavable` and `Save()`.
 
@@ -535,7 +532,7 @@ public void Root_FindsAggregateRoot()
     Assert.Null(order.Root);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L919-L942' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-root' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L918-L941' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-root' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Save Operations
@@ -636,7 +633,7 @@ public void Delete_MarksForDeletion()
     Assert.False(employee.IsDeleted);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L944-L964' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-delete' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L943-L963' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-delete' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### State Management Methods
@@ -647,7 +644,6 @@ protected virtual void MarkOld()
 protected virtual void MarkModified()
 protected virtual void MarkUnmodified()
 protected virtual void MarkDeleted()
-protected virtual void MarkAsChild()
 ```
 
 Control entity state programmatically. `MarkUnmodified()` is called automatically after successful Insert/Update operations.
@@ -677,7 +673,7 @@ public void MarkMethods_ControlEntityState()
     Assert.False(employee.IsDeleted);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L966-L988' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-mark-methods' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L965-L987' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitybase-mark-methods' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Property Access
@@ -743,7 +739,7 @@ public void ValidateListBase_ParentRelationship()
     Assert.Same(address, address.Items.Parent);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L990-L1011' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-parent' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L989-L1010' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-parent' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Aggregated Meta Properties
@@ -783,7 +779,7 @@ public async Task ValidateListBase_AggregatesState()
     Assert.True(list.IsSelfValid); // Lists have no own validation
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1013-L1036' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-metaproperties' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1012-L1035' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-metaproperties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Validation Operations
@@ -828,7 +824,7 @@ public async Task ValidateListBase_RunRulesOnAll()
     Assert.Empty(item1.PropertyMessages);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1038-L1066' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-validation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1037-L1065' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-validation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Task Management
@@ -897,7 +893,7 @@ public void ValidateListBase_StandardOperations()
     Assert.Empty(list);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1068-L1094' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-collection-ops' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1067-L1093' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-validatelistbase-collection-ops' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ---
@@ -922,7 +918,6 @@ public bool IsSelfModified { get; }     // Always false (lists have no own prope
 public bool IsMarkedModified { get; }   // Always false
 public bool IsNew { get; }              // Always false
 public bool IsDeleted { get; }          // Always false
-public bool IsChild { get; }            // Always false
 ```
 
 Lists derive their modification state from their items and deleted list. `IsSavable` is not present -- lists are always saved through the aggregate root, and the property was always false (dead code).
@@ -957,7 +952,7 @@ public void EntityListBase_ModificationFromItems()
     Assert.False(order.Items.IsSelfModified);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1096-L1123' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitylistbase-metaproperties' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1095-L1122' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitylistbase-metaproperties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Aggregate Root
@@ -1003,14 +998,14 @@ public void EntityListBase_TracksDeleted()
     Assert.Equal(1, order.Items.DeletedCount);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1125-L1149' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitylistbase-deletedlist' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1124-L1148' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitylistbase-deletedlist' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Collection Operations
 
 When adding items:
 - Undeletes previously deleted items if re-added from the same aggregate
-- Marks items as child entities (`IsChild = true`)
+- Adds items to the aggregate (the item's `Root` points to the aggregate root)
 - Sets Parent reference to the list's parent (not to the list)
 - Sets ContainingList reference to this collection
 - Prevents adding items that are already in a different containing list
@@ -1037,8 +1032,7 @@ public void EntityListBase_AddRemoveBehavior()
     newItem.ProductCode = "NEW-001";
     order.Items.Add(newItem);
 
-    // Item is marked as child and is new
-    Assert.True(newItem.IsChild);
+    // Item is new and parented to the aggregate root
     Assert.True(newItem.IsNew);
     Assert.Same(order, newItem.Parent);
 
@@ -1059,7 +1053,7 @@ public void EntityListBase_AddRemoveBehavior()
     Assert.True(existingItem.IsDeleted);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1151-L1186' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitylistbase-add-remove' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1150-L1184' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-entitylistbase-add-remove' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Factory Lifecycle
@@ -1119,7 +1113,7 @@ public void IValidateBase_CoreValidationInterface()
     Assert.NotNull(nameProperty);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1188-L1210' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ivalidatebase' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1186-L1208' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ivalidatebase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### IEntityBase
@@ -1149,7 +1143,6 @@ public void IEntityBase_EntityInterface()
     // IEntityBase adds persistence properties
     Assert.True(employee.IsNew);  // After Create, IsNew is true
     Assert.False(employee.IsDeleted);
-    Assert.False(employee.IsChild);
     Assert.True(employee.IsModified);  // New entity is considered modified
 
     // Delete and UnDelete methods
@@ -1163,14 +1156,14 @@ public void IEntityBase_EntityInterface()
     Assert.Null(employee.Root);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1212-L1235' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ientitybase' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1210-L1232' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ientitybase' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### IEntityRoot
 
 Extends `IEntityBase` with `IsSavable` and `Save()` for aggregate roots. Child entities should use `IEntityBase` -- they cannot save independently, and `IsSavable`/`Save()` should not appear on their interface.
 
-The separation exists because `IsSavable` on `EntityBase` includes a `!IsChild` check, making it always false for child entities. Developers naturally used `IsSavable` in save cascade logic to check whether children need persisting, but it silently returned false, skipping saves. Rather than fixing the semantics, the right answer is to remove `IsSavable` and `Save()` from the child interface entirely. Child entity `[Insert]`/`[Update]` methods have signatures that outside consumers cannot fulfill, and entity classes are `internal`, so external callers should never save children at all.
+The separation exists because `EntityBase` defines `IsSavable` (`IsModified && IsValid && !IsBusy`) and `Save()` as concrete members, so a modified child *concrete* looks savable -- but children are persisted by their aggregate root, never on their own. Exposing `IsSavable`/`Save()` on a child interface is misleading: developers naturally use `IsSavable` in save-cascade logic and try to call `Save()` on a child, which the framework does not support (a real production bug in zTreatment). The right answer is to keep `IsSavable` and `Save()` off the child interface entirely. Child entity `[Insert]`/`[Update]` methods have signatures that outside consumers cannot fulfill, and entity classes are `internal`, so external callers should never save children at all.
 
 ```csharp
 public interface IEntityRoot : IEntityBase
@@ -1252,7 +1245,7 @@ public async Task IValidateProperty_PropertyInterface()
     await property.WaitForTasks();
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1237-L1271' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ivalidateproperty' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1234-L1268' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ivalidateproperty' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### IEntityProperty
@@ -1300,7 +1293,7 @@ public void IPropertyInfo_PropertyMetadata()
     Assert.Equal(typeof(string), property.Type);
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1273-L1287' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ipropertyinfo' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1270-L1284' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-ipropertyinfo' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### IValidateMetaProperties
@@ -1324,7 +1317,6 @@ Meta property interface for entity state. Note that `IsSavable` is not part of t
 ```csharp
 public interface IEntityMetaProperties : IFactorySaveMeta
 {
-    bool IsChild { get; }
     bool IsModified { get; }
     bool IsSelfModified { get; }
     bool IsMarkedModified { get; }
@@ -1351,7 +1343,6 @@ public void IMetaProperties_ValidationAndEntityState()
     IEntityMetaProperties entityMeta = employeeFactory.Create();
     Assert.True(entityMeta.IsNew);  // After Create
     Assert.False(entityMeta.IsDeleted);
-    Assert.False(entityMeta.IsChild);
     Assert.True(entityMeta.IsModified);  // New entity
     Assert.False(entityMeta.IsSelfModified);
     Assert.False(entityMeta.IsMarkedModified);
@@ -1360,7 +1351,7 @@ public void IMetaProperties_ValidationAndEntityState()
     Assert.True(((IEntityRoot)entityMeta).IsSavable);  // New entity is savable
 }
 ```
-<sup><a href='/src/samples/ApiReferenceSamples.cs#L1289-L1315' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-imetaproperties' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/ApiReferenceSamples.cs#L1286-L1311' title='Snippet source file'>snippet source</a> | <a href='#snippet-api-interfaces-imetaproperties' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ---

--- a/docs/release-notes/v0.31.0.md
+++ b/docs/release-notes/v0.31.0.md
@@ -1,0 +1,44 @@
+# Neatoo 0.31.0
+
+**Release Date:** 2026-06-17
+**Type:** Minor
+**Breaking Changes:** Yes
+
+---
+
+## Summary
+
+Removes the `IsChild` flag from `EntityBase` and its surrounding machinery. `IsChild` was a save-barrier intended to stop non-root entities from being saved directly, but it never did that reliably: it was only set when an entity was added to a list at runtime, and was **not** set for children loaded from persistence during a (paused) `Fetch`. The real guarantee that children cannot be saved directly is — and always was — the **interface-first design**: child entity interfaces extend `IEntityBase`, which exposes neither `Save()` nor `IsSavable`, and concrete entity classes are `internal`.
+
+With `IsChild` gone, `IsSavable` is now `IsModified && IsValid && !IsBusy`.
+
+---
+
+## What Changed
+
+### Removed
+
+- **`IEntityMetaProperties.IsChild`** — removed from the public interface. There is no replacement property.
+- **`EntityBase<T>.IsChild`**, **`EntityListBase<I>.IsChild`**, **`EntityLazyLoad<T>.IsChild`** — removed.
+- **`SaveFailureReason.IsChildObject`** — removed from the enum, along with the `Save()` guard that threw it. Calling `Save()` on a child concrete from inside the aggregate no longer throws this specific exception.
+- **`MarkAsChild()`** — removed from `EntityBase<T>` and from the internal `IEntityBaseInternal` interface; `EntityListBase` no longer calls it when adding items.
+- `IsChild` is **no longer serialized** (it was previously written via `IEntityMetaProperties` reflection).
+
+### Changed
+
+- **`IsSavable`** is now `IsModified && IsValid && !IsBusy` (the `!IsChild` term is gone). It remains exposed only through `IEntityRoot`.
+
+### Unchanged
+
+- Child persistence is unaffected: the aggregate root's `Save()` still cascades to children via the parent's `[Insert]`/`[Update]`/`[Delete]`. `Root`, `Parent`, `ContainingList`, and `DeletedList` are unchanged — delete tracking never depended on `IsChild`.
+- The interface-first guarantee is unchanged: consumers still cannot call `Save()` or read `IsSavable` on a child, because child interfaces extend `IEntityBase`.
+
+---
+
+## Migration Guide
+
+- **Reading `IsChild`.** There is no replacement. To distinguish an aggregate root from a child, rely on the interface split (root interfaces extend `IEntityRoot`; child interfaces extend `IEntityBase`) or check `Root`/`Parent`. A root's `Root` is `null`; a child's `Root` points to the aggregate root.
+- **Catching `SaveOperationException` with `SaveFailureReason.IsChildObject`.** This reason no longer exists. You should not be calling `Save()` on a child at all — child interfaces do not expose it. If you held a child concrete and called `Save()` on it, remove that call and save the aggregate root instead.
+- **Code that read `IsChild` off `IEntityMetaProperties`** (e.g. custom serialization or diagnostics) must drop that field; it is no longer present and no longer transferred over the wire.
+
+One behavioral note: a child **concrete** that is modified and valid now reports `IsSavable == true` (the concrete still has `IsSavable`). This is only observable if you hold the concrete or a root-typed reference to a child; through the proper child interface (`IEntityBase`), `IsSavable` is not visible.

--- a/docs/vsCSLA/concept-map.md
+++ b/docs/vsCSLA/concept-map.md
@@ -27,7 +27,7 @@ Neatoo's equivalent of CSLA's DataPortal is split into the **RemoteFactory** —
 | `DataPortal.Fetch<T>()` | `factory.Fetch()` / `factory.FetchAsync()` | Generated from `[Fetch]` method | Documented (RemoteFactory skill) |
 | `DataPortal.Update()` / `Save()` | `entity.Save()` / `factory.SaveAsync()` | Routes to `[Insert]`/`[Update]`/`[Delete]` based on state | Documented |
 | `DataPortal.Delete<T>()` | `entity.Delete()` then `Save()` | Deferred deletion pattern | Documented |
-| `DataPortal.CreateChild<T>()` | `childFactory.Create()` | No separate child factory — same factory, framework sets `IsChild` on list add | Documented |
+| `DataPortal.CreateChild<T>()` | `childFactory.Create()` | No separate child factory — same factory; a child's `Root` points to the aggregate root after list add | Documented |
 | `DataPortal_Create` | `[Create] public void Create()` | Method attribute instead of convention | Documented |
 | `DataPortal_Fetch` | `[Fetch] public void Fetch(...)` | Method attribute | Documented |
 | `DataPortal_Insert` | `[Insert] public void Insert(...)` | Method attribute. Parent/child relationship is explicit in method parameters (e.g., child `[Insert]` takes parent ID). More explicit than CSLA. | Documented |
@@ -112,10 +112,10 @@ Authorization is handled by **RemoteFactory**, not Neatoo core. The RemoteFactor
 | `IsSelfDirty` | `IsSelfModified` | Same rename | Documented |
 | `IsValid` | `IsValid` | Same | Documented |
 | `IsSelfValid` | `IsSelfValid` | Same | Documented |
-| `IsSavable` | `IsSavable` | Same formula, only on `IEntityRoot` | Documented |
+| `IsSavable` | `IsSavable` | Only on `IEntityRoot`; Neatoo's formula omits the `!IsChild` term | Documented |
 | `IsNew` | `IsNew` | Same | Documented |
 | `IsDeleted` | `IsDeleted` | Same | Documented |
-| `IsChild` | `IsChild` | Same | Documented |
+| `IsChild` | _(removed)_ | Neatoo has no `IsChild`; children are constrained by the `IEntityBase` interface (no `Save()`/`IsSavable`) | Documented |
 | `IsBusy` | `IsBusy` | Same | Documented |
 | `MarkNew()` | `MarkNew()` (protected) | Exposed via wrapper in tests | Partially documented |
 | `MarkOld()` | `MarkOld()` (protected) | Exposed via wrapper in tests | Partially documented |

--- a/docs/vsCSLA/csla-and-ddd.md
+++ b/docs/vsCSLA/csla-and-ddd.md
@@ -19,7 +19,7 @@ They happen to agree that the answer involves self-validating objects with save 
 | Save boundary = root object | Aggregate root | Editable root (children can't self-save) | Yes |
 | Identity tracking | Entity has identity | `BusinessBase` tracks `IsNew`, state | Yes |
 | Persistence separated from domain | Repository pattern | DataPortal abstracts persistence | Yes |
-| Children can't be saved independently | Aggregate consistency | `IsChild` prevents independent save | Yes |
+| Children can't be saved independently | Aggregate consistency | Child interface (`IEntityBase`) has no `Save()`; the root persists children | Yes |
 
 ## Where they diverge
 

--- a/skills/mudneatoo/SKILL.md
+++ b/skills/mudneatoo/SKILL.md
@@ -254,7 +254,7 @@ A complete form page follows this structure:
 ### Key Points in the Page Structure
 
 1. **Inject the factory interface** — not the concrete class
-2. **Use `IsSavable` to disable save button** — it combines `IsValid && IsModified && !IsBusy && !IsChild`
+2. **Use `IsSavable` to disable save button** — it combines `IsValid && IsModified && !IsBusy`
 3. **Subscribe to `PropertyChanged`** — so Blazor re-renders when `IsSavable` changes. This is sufficient here because root meta flags (`IsValid`, `IsModified`, `IsBusy`) bubble through `PropertyChanged` even when the trigger is a descendant change. For components that need to react to descendant *property names* (e.g. a custom validation summary), use `NeatooPropertyChanged` instead. See `references/property-change-events.md`.
 4. **Call `WaitForTasks()` before save** — ensures async validation completes
 5. **Replace the entity reference after save** — `Save()` returns the updated entity

--- a/skills/neatoo/SKILL.md
+++ b/skills/neatoo/SKILL.md
@@ -99,6 +99,32 @@ Every user interaction in a Neatoo app follows three sequential, non-overlapping
 | `[Service]` parameter injection | Read `Parent` reference for ambient root state |
 | DB-snapshot-vs-in-memory diffing | (No `[Service]` injection, no repositories, no transactions, no event raises) |
 
+### Self-Only Persistence — Factory Methods Touch ONLY Their Own Entity
+
+A Neatoo entity's factory methods persist **that entity and nothing else**. The save cascade handles children by calling `childFactory.Save`; it does NOT reach across aggregates or into sibling entities' EF rows.
+
+**Hard rules:**
+
+- **A Neatoo entity must NOT `MapTo` / `MapFrom` another entity's EF row.** `Visit`'s factory maps `Visit ↔ VisitEntity`. It does NOT map `PlanEntity`, `TreatmentEntity`, `PatientEntity`, or any other table. If you need a sibling's data, load that sibling as a child via its own factory.
+- **A Neatoo factory method must NOT inject another entity's `IXxxRepository`.** `VisitFactory` may inject `IVisitRepository`. It must NOT inject `IPlanRepository`, `ITreatmentRepository`, etc. Cross-entity persistence happens through child factories (`childFactory.Save`), not by reaching into a foreign repository.
+- **No "while I'm here" writes.** Don't update a sibling row inline because it's convenient — that breaks the save cascade contract and hides the dependency from the aggregate graph.
+
+**Why this is non-negotiable:** the save cascade depends on every entity owning its own row. The moment one entity writes another's row, you have two writers for one row, ambiguous ordering, broken `IsModified` accounting, and silent data corruption when the "real" owner saves later. Cross-entity edits must go through the owning entity's business methods + factory, full stop.
+
+**Rare-exception protocol (NOT a precedent):**
+
+In the rare case a cross-entity touch is genuinely required and **the user has explicitly approved it**, the code MUST carry an inline comment of this exact shape:
+
+```csharp
+// CROSS-ENTITY EXCEPTION — APPROVED BY USER on <date>
+// Why: <one-sentence justification>
+// DO NOT REPEAT — this is not a pattern. Default is self-only persistence.
+```
+
+No approval comment, no exception. Reviewers reject on sight.
+
+**Local code is not the standard.** If you find an existing entity that violates self-only (maps a sibling, injects a foreign repository), that is residue, not a pattern to copy. Ask before mirroring it.
+
 ### What the Save Needs Must Be State
 
 Factory methods can only read what's on the entity graph. They cannot read call-context, local variables from the business method that triggered the save, or "intentions" the caller held in their head.
@@ -244,7 +270,7 @@ The coupling concerns DDD raises are real — they apply to coupling *across* ag
 | `IsSelfModified` | bool | This object's own properties changed (excludes children, excludes IsNew) |
 | `IsValid` | bool | This object and all children pass validation |
 | `IsSelfValid` | bool | This object (only) passes validation |
-| `IsSavable` | bool | `IsValid && IsModified && !IsBusy && !IsChild` |
+| `IsSavable` | bool | `IsValid && IsModified && !IsBusy` |
 | `IsNew` | bool | Not yet persisted. Set true by Create, set false by Fetch/Insert. Implies `IsModified`. |
 | `IsDeleted` | bool | Marked for deletion |
 | `RuleManager` | IRuleManager | Access to validation rules |

--- a/skills/neatoo/references/entities.md
+++ b/skills/neatoo/references/entities.md
@@ -287,18 +287,16 @@ public void IsSavable_CombinesStateChecks()
     Assert.True(order.IsModified);    // Something changed
     Assert.True(order.IsValid);       // Passes validation
     Assert.False(order.IsBusy);       // No async operations
-    Assert.False(order.IsChild);      // Not a child entity
     Assert.True(order.IsSavable);     // Can save!
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L631-L654' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L631-L653' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-savable' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `IsSavable` returns `true` when:
 - `IsValid == true` (passes validation)
 - `IsModified == true` (has changes)
 - `IsBusy == false` (no async operations pending)
-- `IsChild == false` (not a child entity -- children are saved through the aggregate root)
 
 ## Child Entity State
 
@@ -321,11 +319,10 @@ public void ChildEntity_CannotSaveDirectly()
     item.Price = 29.99m;
     item.Quantity = 1;
 
-    // Add to collection marks entity as child
+    // Add to collection (the item becomes part of the aggregate)
     order.Items.Add(item);
 
-    // Child entity state
-    Assert.True(item.IsChild);
+    // Child entity is reachable through its aggregate root
     Assert.Same(order, item.Root);
 
     // Child interfaces (IEntityBase) don't expose IsSavable or Save().
@@ -333,7 +330,7 @@ public void ChildEntity_CannotSaveDirectly()
     // This is enforced at the type level — no runtime check needed.
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L656-L682' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L655-L680' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-child-state' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Factory Services
@@ -358,7 +355,7 @@ public void Factory_SetThroughDependencyInjection()
     // The factory calls Insert, Update, or Delete based on entity state
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L684-L699' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L682-L697' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-factory-services' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Save Cancellation
@@ -388,7 +385,7 @@ public async Task Save_SupportsCancellation()
     Assert.True(order.IsModified);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L701-L721' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L699-L719' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-save-cancellation' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Parent Property
@@ -568,7 +565,7 @@ public async Task CascadeSave_OnlyRootSavedExternally()
     Assert.False(saved.IsNew);
 }
 ```
-<sup><a href='/src/samples/EntitiesSamples.cs#L796-L817' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-cascade-correct-external' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/samples/EntitiesSamples.cs#L772-L793' title='Snippet source file'>snippet source</a> | <a href='#snippet-entities-cascade-correct-external' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Rules

--- a/src/Design/CLAUDE-DESIGN.md
+++ b/src/Design/CLAUDE-DESIGN.md
@@ -57,9 +57,9 @@ public interface IOrderItem : IEntityBase { ... }
 
 The concrete `EntityBase<T>` implements both `IEntityBase` and `IEntityRoot`, so it retains `IsSavable` and `Save()` as concrete members. This does not matter because entity classes should be `internal` -- consumers interact through the interface, which is the access control mechanism.
 
-**Why this design exists:** `IsSavable` on `EntityBase` includes a `!IsChild` check, making it always false for child entities. This created a trap where developers used `IsSavable` in save cascade logic to check whether children need persisting, but it silently returned false, skipping saves. This caused a real production bug (zTreatment). The right fix is not to make `IsSavable` work on children -- it is to remove it from the child interface entirely. Child entity factory methods (`[Insert]`/`[Update]`) have signatures that outside consumers cannot fulfill (they often need the parent entity or parent ID). Combined with `internal` on entity classes, external callers should not be able to save children at all.
+**Why this design exists:** `EntityBase` defines `IsSavable` (`IsModified && IsValid && !IsBusy`) and `Save()` as concrete members, so a modified child *concrete* looks savable -- but children are persisted by their aggregate root, never on their own. Exposing `IsSavable`/`Save()` on a child interface is therefore misleading: it invites developers to use them in save-cascade logic and to call `Save()` on a child, which the framework does not support. (This caused a real production bug in zTreatment, where `IsSavable` was used to decide whether children needed persisting.) The fix is to keep `IsSavable`/`Save()` off the child interface entirely. Child entity factory methods (`[Insert]`/`[Update]`) also have signatures that outside consumers cannot fulfill (they often need the parent entity or parent ID); combined with `internal` on entity classes, external callers cannot save children at all.
 
-**EntityListBase does not expose IsSavable.** `IsSavable` on entity lists was always false for every child -- it was faithfully propagating a lie. Removing it from the interface is not losing functionality.
+**EntityListBase does not expose IsSavable.** Lists are always persisted through the aggregate root, so a list never needs a savability flag. Removing it from the interface is not losing functionality.
 
 See `Design.Domain/Aggregates/OrderAggregate/IOrderInterfaces.cs` for the authoritative example.
 
@@ -70,7 +70,7 @@ See `Design.Domain/Aggregates/OrderAggregate/IOrderInterfaces.cs` for the author
 **EntityBase<T>** - Use for persistent entities:
 - Has IsNew, IsModified, IsDeleted, IsSavable, Save()
 - Save() routes to Insert/Update/Delete based on state
-- Child entities have IsChild=true and cannot save independently
+- Child entities cannot save independently -- they are persisted by the aggregate root
 - Root entity interfaces extend `IEntityRoot` (exposes IsSavable, Save())
 - Child entity interfaces extend `IEntityBase` (no IsSavable, no Save())
 
@@ -190,7 +190,7 @@ This routing is determined by Neatoo's state properties, not RemoteFactory.
 ### Adding a Child Entity
 
 Same as above, but:
-- The entity will have `IsChild=true` when added to an EntityListBase
+- The entity becomes part of the aggregate when added to an EntityListBase (its `Root` points to the aggregate root)
 - Do NOT add `[Remote]` to Insert/Update/Delete - parent handles persistence
 - The child entity interface extends `IEntityBase` (NOT `IEntityRoot`) -- consumers cannot access `IsSavable` or `Save()` on child entities
 - Child `[Insert]`/`[Update]` methods often require the parent entity or parent ID as parameters, which outside consumers cannot fulfill
@@ -310,8 +310,7 @@ When updating Design projects:
 | `IsModified` | EntityBase | Has unsaved changes (includes children) |
 | `IsSelfModified` | EntityBase | This object has changes (excludes children) |
 | `IsDeleted` | EntityBase | Marked for deletion |
-| `IsSavable` | EntityBase (IEntityRoot only) | IsModified && IsValid && !IsBusy && !IsChild. Only on `IEntityRoot` interface -- not on `IEntityBase` or entity lists |
-| `IsChild` | EntityBase | Part of parent aggregate |
+| `IsSavable` | EntityBase (IEntityRoot only) | IsModified && IsValid && !IsBusy. Only on `IEntityRoot` interface -- not on `IEntityBase` or entity lists |
 | `IsValid` | ValidateBase | All rules pass (includes children) |
 | `IsSelfValid` | ValidateBase | This object's rules pass (excludes children) |
 | `IsBusy` | ValidateBase | Async operations pending |
@@ -410,7 +409,6 @@ Neatoo uses custom JSON converters for client-server state transfer:
 | `IsNew` | Yes | Via `IEntityMetaProperties` |
 | `IsDeleted` | Yes | Via `IEntityMetaProperties` |
 | `IsModified` | Yes | Via `IEntityMetaProperties` |
-| `IsChild` | Yes | Via `IEntityMetaProperties` |
 | `DeletedList` items | Yes | Serialized as part of list |
 | Validation messages | No | Rules re-run on deserialization |
 | `IsBusy` | No | Reset on deserialization |

--- a/src/Design/Design.Domain/Aggregates/OrderAggregate/IOrderInterfaces.cs
+++ b/src/Design/Design.Domain/Aggregates/OrderAggregate/IOrderInterfaces.cs
@@ -30,7 +30,8 @@
 //
 // WRONG:
 //   public interface IOrderItem : IEntityRoot { ... }
-//   // IOrderItem.IsSavable is always false (IsChild=true), confusing
+//   // Exposes IsSavable/Save() on a child — but children are persisted by the
+//   // aggregate root, so a savable-looking child is misleading and unsupported.
 //
 // RIGHT:
 //   public interface IOrderItem : IEntityBase { ... }

--- a/src/Design/Design.Domain/Aggregates/OrderAggregate/Order.cs
+++ b/src/Design/Design.Domain/Aggregates/OrderAggregate/Order.cs
@@ -136,11 +136,11 @@ internal partial class Order : EntityBase<Order>, IOrder
                 item["LineTotal"].LoadValue(itemData.LineTotal);
 
                 Items.Add(item);
-                // item.IsChild = true, item.ContainingList = Items
+                // item.ContainingList = Items, item.Root = this Order
             }
         }
         // After Fetch: Order.IsNew=false, Order.IsModified=false
-        // Each item: IsNew=false, IsModified=false, IsChild=true
+        // Each item: IsNew=false, IsModified=false
     }
 
     // =========================================================================

--- a/src/Design/Design.Domain/Aggregates/OrderAggregate/OrderItem.cs
+++ b/src/Design/Design.Domain/Aggregates/OrderAggregate/OrderItem.cs
@@ -15,7 +15,7 @@ namespace Design.Domain.Aggregates.OrderAggregate;
 /// Demonstrates: Child entity within an aggregate.
 ///
 /// Key points:
-/// - IsChild=true when in OrderItemList (cannot save independently)
+/// - In an OrderItemList; not savable on its own (IOrderItem has no Save())
 /// - ContainingList tracks which list owns this item
 /// - Root property points to Order (aggregate root)
 /// - Delete/UnDelete managed by list operations
@@ -66,9 +66,8 @@ internal partial class OrderItem : EntityBase<OrderItem>, IOrderItem
     // =========================================================================
     // When OrderItem is in a list:
     //
-    // IsChild = true
-    //   - Set by list.Add() calling MarkAsChild()
-    //   - Makes IsSavable = false (cannot save independently)
+    // Root = the Order (aggregate root)
+    //   - Walked from ContainingList; child persists through the root's Save()
     //
     // ContainingList = the OrderItemList
     //   - Set by list.Add() calling SetContainingList()
@@ -123,9 +122,8 @@ internal partial class OrderItem : EntityBase<OrderItem>, IOrderItem
 //      - Remove from old list's DeletedList (intra-aggregate move)
 //   5. If item.IsDeleted: item.UnDelete()
 //   6. If !item.IsNew: item.MarkModified()
-//   7. item.MarkAsChild() -> IsChild = true
-//   8. item.SetContainingList(this)
-//   9. Add to collection
+//   7. item.SetContainingList(this)
+//   8. Add to collection
 //
 // REMOVING EXISTING ITEM:
 //   var item = order.Items[0];  // item.IsNew = false
@@ -175,9 +173,8 @@ internal partial class OrderItem : EntityBase<OrderItem>, IOrderItem
 //
 // WRONG:
 //   order.Items[0].ProductName = "New Name";
-//   await order.Items[0].Save();
-//   // THROWS: SaveOperationException(SaveFailureReason.IsChildObject)
-//   // Because: order.Items[0].IsChild = true -> IsSavable = false
+//   order.Items[0].Save();
+//   // Does not compile: IOrderItem extends IEntityBase, which has no Save()
 //
 // RIGHT:
 //   order.Items[0].ProductName = "New Name";

--- a/src/Design/Design.Domain/Aggregates/OrderAggregate/OrderItemList.cs
+++ b/src/Design/Design.Domain/Aggregates/OrderAggregate/OrderItemList.cs
@@ -94,7 +94,7 @@ internal partial class OrderItemList : EntityListBase<IOrderItem>, IOrderItemLis
 //   var order = await orderFactory.Fetch(1);
 //   var newItem = orderItemFactory.Create("New Product", 5, 10.00m);
 //   order.Items.Add(newItem);
-//   // newItem: IsNew=true, IsChild=true, ContainingList=order.Items
+//   // newItem: IsNew=true, ContainingList=order.Items
 //
 // Remove:
 //   order.Items.Remove(newItem);
@@ -124,7 +124,7 @@ internal partial class OrderItemList : EntityListBase<IOrderItem>, IOrderItemLis
 // Add new:
 //   var newItem = orderItemFactory.Create("New", 1, 5.00m);
 //   order.Items.Add(newItem);
-//   // newItem: IsNew=true, IsChild=true
+//   // newItem: IsNew=true
 //
 // Remove existing:
 //   var removedItem = order.Items[1];

--- a/src/Design/Design.Domain/BaseClasses/AllBaseClasses.cs
+++ b/src/Design/Design.Domain/BaseClasses/AllBaseClasses.cs
@@ -149,10 +149,9 @@ internal partial class DemoValueObject : ValidateBase<DemoValueObject>, IDemoVal
 // - IsModified: True when any property changed (including children)
 // - IsSelfModified: True when THIS object's properties changed (excluding children)
 // - IsDeleted: True when marked for deletion
-// - IsSavable: True when entity can be saved (Modified && Valid && !Busy && !Child)
+// - IsSavable: True when entity can be saved (Modified && Valid && !Busy)
 //              Exposed only through IEntityRoot (aggregate root interface)
-// - IsChild: True when part of a parent aggregate (cannot save independently)
-// - Root: Reference to aggregate root
+// - Root: Reference to aggregate root (null for the root itself)
 // - ModifiedProperties: List of changed property names
 // - Factory: Reference to IFactorySave<T> for persistence operations
 //
@@ -187,9 +186,9 @@ internal partial class DemoValueObject : ValidateBase<DemoValueObject>, IDemoVal
 /// Key points:
 /// - Inherits all ValidateBase capabilities (validation, rules, busy tracking)
 /// - Adds IsNew/IsModified/IsDeleted for persistence state
-/// - IsSavable = IsModified &amp;&amp; IsValid &amp;&amp; !IsBusy &amp;&amp; !IsChild
+/// - IsSavable = IsModified &amp;&amp; IsValid &amp;&amp; !IsBusy
 /// - Save() routes to Insert/Update/Delete based on state
-/// - Child entities (IsChild=true) cannot save independently
+/// - Child entities are not savable through their interface (IEntityBase has no Save())
 /// </summary>
 [Factory]
 internal partial class DemoEntity : EntityBase<DemoEntity>, IDemoEntity
@@ -445,7 +444,7 @@ internal partial class DemoValueObjectList : ValidateListBase<IDemoValueObject>,
 /// - Extends ValidateListBase with persistence tracking
 /// - IsModified = any child modified OR DeletedList has items
 /// - DeletedList tracks removed non-new items for persistence deletion
-/// - Adding items: MarkAsChild(), set ContainingList
+/// - Adding items: set ContainingList
 /// - Removing non-new items: MarkDeleted(), add to DeletedList
 /// - Root property for aggregate boundary enforcement
 /// </summary>
@@ -514,7 +513,7 @@ public interface IDemoRepository
 //
 // INTERFACE HIERARCHY for entities:
 //
-//   IEntityBase              (child entities: IsModified, IsChild, Delete, etc.)
+//   IEntityBase              (child entities: IsModified, Delete, etc.)
 //        ^
 //        |
 //   IEntityRoot              (aggregate roots: adds IsSavable, Save())
@@ -533,7 +532,7 @@ public interface IDemoRepository
 // WRONG:
 //   var parent = await ParentFactory.Fetch(id);
 //   parent.Children[0].Name = "New Name";
-//   await parent.Children[0].Save();  // THROWS: IsChild=true, IsSavable=false
+//   parent.Children[0].Save();  // Does not compile: IEntityBase has no Save()
 //
 // RIGHT:
 //   await parent.Save();  // Parent save persists all child changes

--- a/src/Design/Design.Domain/Entities/Address.cs
+++ b/src/Design/Design.Domain/Entities/Address.cs
@@ -15,8 +15,8 @@ namespace Design.Domain.Entities;
 /// Demonstrates: Child entity within an aggregate.
 ///
 /// Key points:
-/// - Part of Employee aggregate (IsChild=true when in AddressList)
-/// - Cannot call Save() directly (IsSavable always false when IsChild)
+/// - Part of Employee aggregate (added to AddressList)
+/// - Cannot call Save() directly — its child interface has no Save(); persisted by Employee
 /// - Insert/Update/Delete called by parent's persistence methods
 /// - Has own validation rules
 /// </summary>
@@ -132,9 +132,8 @@ internal partial class Address : EntityBase<Address>, IAddress
 // =============================================================================
 // When an Address is added to AddressList:
 // 1. InsertItem() is called on the list
-// 2. MarkAsChild() sets address.IsChild = true
-// 3. SetContainingList() tracks ownership
-// 4. If address was deleted, UnDelete() is called
+// 2. SetContainingList() tracks ownership (Root walks to the Employee)
+// 3. If address was deleted, UnDelete() is called
 //
 // When an Address is removed from AddressList:
 // 1. RemoveItem() is called on the list
@@ -155,8 +154,7 @@ internal partial class Address : EntityBase<Address>, IAddress
 // WRONG:
 //   var employee = await employeeFactory.Fetch(1);
 //   employee.Addresses[0].City = "Seattle";
-//   await employee.Addresses[0].Save();  // THROWS SaveOperationException!
-//   // SaveFailureReason.IsChildObject
+//   employee.Addresses[0].Save();  // Does not compile: child interface has no Save()
 //
 // RIGHT:
 //   var employee = await employeeFactory.Fetch(1);

--- a/src/Design/Design.Domain/Entities/Employee.cs
+++ b/src/Design/Design.Domain/Entities/Employee.cs
@@ -151,7 +151,7 @@ internal partial class Employee : EntityBase<Employee>, IEmployee
                 address["AddressType"].LoadValue(addrData.AddressType);
 
                 Addresses.Add(address);
-                // Add sets: address.IsChild=true, address.ContainingList=Addresses
+                // Add sets: address.ContainingList=Addresses, address.Root=this Employee
             }
         }
         // After Fetch: IsNew=false, IsModified=false for Employee and all Addresses

--- a/src/Design/Design.Domain/FactoryOperations/FetchPatterns.cs
+++ b/src/Design/Design.Domain/FactoryOperations/FetchPatterns.cs
@@ -231,14 +231,14 @@ internal partial class FetchWithChildrenDemo : EntityBase<FetchWithChildrenDemo>
                 item["Id"].LoadValue(childData.Id);
                 item["Name"].LoadValue(childData.Name);
 
-                // Add to list - this sets IsChild=true on the item
+                // Add to list - establishes ContainingList and Root on the item
                 Items.Add(item);
             }
         }
 
         // After fetch:
         // - Parent: IsNew=false, IsModified=false
-        // - Each child: IsNew=false, IsModified=false, IsChild=true
+        // - Each child: IsNew=false, IsModified=false
     }
 
     [Remote]

--- a/src/Design/Design.Domain/FactoryOperations/SavePatterns.cs
+++ b/src/Design/Design.Domain/FactoryOperations/SavePatterns.cs
@@ -330,7 +330,7 @@ internal partial class SaveDemoItem : EntityBase<SaveDemoItem>, ISaveDemoItem
     // REJECTED PATTERN:
     //   // In parent Update:
     //   foreach (var item in Items) {
-    //       await item.Save();  // NO! Child can't save (IsChild=true)
+    //       item.Save();  // NO! Won't compile — child interface has no Save()
     //   }
     //
     // WHY NOT: Children are part of the aggregate. The aggregate root owns

--- a/src/Design/Design.Domain/PropertySystem/StateProperties.cs
+++ b/src/Design/Design.Domain/PropertySystem/StateProperties.cs
@@ -29,7 +29,6 @@ namespace Design.Domain.PropertySystem;
 // - IsSelfModified: This object's properties changed (excluding children)
 // - IsDeleted: Marked for deletion
 // - IsSavable: Can call Save() successfully
-// - IsChild: Part of a parent aggregate
 // - Root: Reference to aggregate root
 // - ModifiedProperties: Names of changed properties
 // - IsMarkedModified: Explicitly marked (not from property changes)
@@ -208,7 +207,7 @@ internal partial class ModificationChildDemo : EntityBase<ModificationChildDemo>
 }
 
 /// <summary>
-/// Demonstrates: IsSavable, IsDeleted, IsChild, Root.
+/// Demonstrates: IsSavable, IsDeleted, Root.
 /// </summary>
 [Factory]
 internal partial class SaveStateDemo : EntityBase<SaveStateDemo>, ISaveStateDemo
@@ -235,13 +234,16 @@ internal partial class SaveStateDemo : EntityBase<SaveStateDemo>, ISaveStateDemo
     // =========================================================================
     // IsSavable - Can Save() Be Called?
     // =========================================================================
-    // IsSavable = IsModified && IsValid && !IsBusy && !IsChild
+    // IsSavable = IsModified && IsValid && !IsBusy
     //
     // All conditions must be true:
     // - IsModified: Must have changes to persist
     // - IsValid: All validation must pass
     // - !IsBusy: No async operations in progress
-    // - !IsChild: Not a child entity (children save through parent)
+    //
+    // Children are never saved directly: their interfaces (IEntityBase) do not
+    // expose Save()/IsSavable, and concretes are internal. The aggregate root
+    // persists them through its own Save().
     //
     // COMMON MISTAKE: Checking IsSavable without awaiting tasks.
     //
@@ -269,18 +271,21 @@ internal partial class SaveStateDemo : EntityBase<SaveStateDemo>, ISaveStateDemo
     // =========================================================================
 
     // =========================================================================
-    // IsChild - Aggregate Membership
+    // Aggregate Membership - Children Persist Through the Root
     // =========================================================================
-    // IsChild = true: Entity is part of a parent aggregate.
-    //   - Set when added to an EntityListBase
-    //   - Cannot call Save() directly (throws SaveOperationException)
-    //   - Persisted through parent's Save()
+    // A child entity is part of a parent aggregate once added to an
+    // EntityListBase (or assigned as a child property). Its Root points to the
+    // aggregate root.
+    //   - Child interfaces extend IEntityBase, which exposes neither Save() nor
+    //     IsSavable, and concretes are internal — consumers cannot save a child
+    //     on its own.
+    //   - The aggregate root's Save() coordinates persistence of all children.
     //
-    // COMMON MISTAKE: Trying to save child entities.
+    // COMMON MISTAKE: Trying to save child entities directly.
     //
     // WRONG:
     //   parent.Items[0].Name = "Changed";
-    //   await parent.Items[0].Save();  // THROWS! IsChild=true, IsSavable=false
+    //   parent.Items[0].Save();  // Does not compile: IEntityBase has no Save()
     //
     // RIGHT:
     //   parent.Items[0].Name = "Changed";

--- a/src/Design/Design.Tests/AggregateTests/EntityRootInterfaceTests.cs
+++ b/src/Design/Design.Tests/AggregateTests/EntityRootInterfaceTests.cs
@@ -63,7 +63,6 @@ public class EntityRootInterfaceTests
         // This is verified by the fact that the following would NOT compile:
         //   entityBase.IsSavable  // CS1061: IEntityBase does not contain IsSavable
         //   entityBase.Save()     // CS1061: IEntityBase does not contain Save
-        Assert.IsTrue(entityBase.IsChild, "Child entity should be a child");
         Assert.IsTrue(entityBase.IsModified, "Child entity should be modified");
     }
 

--- a/src/Design/Design.Tests/AggregateTests/OrderAggregateTests.cs
+++ b/src/Design/Design.Tests/AggregateTests/OrderAggregateTests.cs
@@ -56,21 +56,6 @@ public class OrderAggregateTests
     }
 
     [TestMethod]
-    public void AddItem_ItemBecomesChild()
-    {
-        // Arrange
-        var order = _orderFactory.Create();
-        var item = _itemFactory.Create("Widget", 5, 10.00m);
-
-        // Act
-        order.Items!.Add(item);
-
-        // Assert
-        Assert.IsTrue(item.IsChild, "Added item should have IsChild=true");
-        Assert.AreEqual(1, order.Items.Count);
-    }
-
-    [TestMethod]
     public void Item_CalculatesLineTotal_OnPropertyChange()
     {
         // Arrange - Create item with initial values
@@ -115,8 +100,8 @@ public class OrderAggregateTests
         // Assert — IOrderItem extends IEntityBase, which does NOT have IsSavable or Save().
         // This is the interface-first pattern at work: the interface controls access.
         // The concrete OrderItem has IsSavable (inherited from EntityBase), but consumers
-        // only see IOrderItem, so IsSavable is invisible.
-        Assert.IsTrue(item.IsChild);
+        // only see IOrderItem, so IsSavable is invisible — a child cannot be saved on its own.
+        Assert.AreEqual(1, order.Items!.Count, "Item is persisted as part of the Order aggregate");
         // item.IsSavable — does not compile: IOrderItem (IEntityBase) has no IsSavable
         // item.Save()    — does not compile: IOrderItem (IEntityBase) has no Save()
     }

--- a/src/Design/Design.Tests/BaseClassTests/EntityListBaseTests.cs
+++ b/src/Design/Design.Tests/BaseClassTests/EntityListBaseTests.cs
@@ -43,21 +43,6 @@ public class EntityListBaseTests
     }
 
     [TestMethod]
-    public void Add_MarksItemAsChild()
-    {
-        // Arrange
-        var list = _listFactory.Create();
-        var item = _itemFactory.Create();
-        item.Name = "Test";
-
-        // Act
-        list.Add(item);
-
-        // Assert
-        Assert.IsTrue(item.IsChild, "Item added to list should have IsChild=true");
-    }
-
-    [TestMethod]
     public void Add_IncreasesCount()
     {
         // Arrange

--- a/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/PersonTests.Stubs.g.cs
+++ b/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/PersonTests.Stubs.g.cs
@@ -7986,9 +7986,6 @@ partial class PersonTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -8197,11 +8194,6 @@ partial class PersonTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -8268,7 +8260,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -8302,7 +8293,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -8336,7 +8326,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8370,7 +8359,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8404,7 +8392,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8438,7 +8425,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8472,7 +8458,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8506,7 +8491,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8540,7 +8524,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8574,7 +8557,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8608,7 +8590,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8642,7 +8623,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8676,7 +8656,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -8710,7 +8689,6 @@ partial class PersonTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -8746,7 +8724,6 @@ partial class PersonTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -8788,7 +8765,6 @@ partial class PersonTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);

--- a/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/UniqueNameRuleTests.Stubs.g.cs
+++ b/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/UniqueNameRuleTests.Stubs.g.cs
@@ -4228,9 +4228,6 @@ partial class UniqueNameRuleTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -4440,11 +4437,6 @@ partial class UniqueNameRuleTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -4513,7 +4505,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4550,7 +4541,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4587,7 +4577,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4624,7 +4613,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4661,7 +4649,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4698,7 +4685,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4735,7 +4721,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4772,7 +4757,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4809,7 +4793,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4846,7 +4829,6 @@ partial class UniqueNameRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4885,7 +4867,6 @@ partial class UniqueNameRuleTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -4929,7 +4910,6 @@ partial class UniqueNameRuleTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);

--- a/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/UniquePhoneNumberRuleTests.Stubs.g.cs
+++ b/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/UniquePhoneNumberRuleTests.Stubs.g.cs
@@ -4228,9 +4228,6 @@ partial class UniquePhoneNumberRuleTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -4440,11 +4437,6 @@ partial class UniquePhoneNumberRuleTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -4513,7 +4505,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4550,7 +4541,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4587,7 +4577,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4624,7 +4613,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4661,7 +4649,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4698,7 +4685,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4735,7 +4721,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4772,7 +4757,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4809,7 +4793,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4846,7 +4829,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4885,7 +4867,6 @@ partial class UniquePhoneNumberRuleTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -4929,7 +4910,6 @@ partial class UniquePhoneNumberRuleTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -10028,9 +10008,6 @@ partial class UniquePhoneNumberRuleTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -10239,11 +10216,6 @@ partial class UniquePhoneNumberRuleTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -10310,7 +10282,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -10344,7 +10315,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -10378,7 +10348,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10412,7 +10381,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10446,7 +10414,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10480,7 +10447,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10514,7 +10480,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10548,7 +10513,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10582,7 +10546,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10616,7 +10579,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10650,7 +10612,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10684,7 +10645,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10718,7 +10678,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -10752,7 +10711,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10788,7 +10746,6 @@ partial class UniquePhoneNumberRuleTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -10830,7 +10787,6 @@ partial class UniquePhoneNumberRuleTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -14192,9 +14148,6 @@ partial class UniquePhoneNumberRuleTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -14374,11 +14327,6 @@ partial class UniquePhoneNumberRuleTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -14444,7 +14392,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -14477,7 +14424,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -14510,7 +14456,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14543,7 +14488,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14576,7 +14520,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14609,7 +14552,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14642,7 +14584,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14675,7 +14616,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -14708,7 +14648,6 @@ partial class UniquePhoneNumberRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14743,7 +14682,6 @@ partial class UniquePhoneNumberRuleTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -14783,7 +14721,6 @@ partial class UniquePhoneNumberRuleTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);

--- a/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/UniquePhoneTypeRuleTests.Stubs.g.cs
+++ b/src/Examples/Person/Person.DomainModel.Tests/Generated/KnockOff.Generator/KnockOff.KnockOffGenerator/UniquePhoneTypeRuleTests.Stubs.g.cs
@@ -4228,9 +4228,6 @@ partial class UniquePhoneTypeRuleTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -4440,11 +4437,6 @@ partial class UniquePhoneTypeRuleTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -4513,7 +4505,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4550,7 +4541,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4587,7 +4577,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4624,7 +4613,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4661,7 +4649,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4698,7 +4685,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4735,7 +4721,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4772,7 +4757,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4809,7 +4793,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -4846,7 +4829,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -4885,7 +4867,6 @@ partial class UniquePhoneTypeRuleTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -4929,7 +4910,6 @@ partial class UniquePhoneTypeRuleTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -10028,9 +10008,6 @@ partial class UniquePhoneTypeRuleTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -10239,11 +10216,6 @@ partial class UniquePhoneTypeRuleTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -10310,7 +10282,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -10344,7 +10315,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -10378,7 +10348,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10412,7 +10381,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10446,7 +10414,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10480,7 +10447,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10514,7 +10480,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10548,7 +10513,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10582,7 +10546,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10616,7 +10579,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10650,7 +10612,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10684,7 +10645,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10718,7 +10678,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -10752,7 +10711,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -10788,7 +10746,6 @@ partial class UniquePhoneTypeRuleTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -10830,7 +10787,6 @@ partial class UniquePhoneTypeRuleTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -14192,9 +14148,6 @@ partial class UniquePhoneTypeRuleTests
 			/// <summary>Interceptor for PropertyMessages.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<global::System.Collections.Generic.IReadOnlyCollection<global::Neatoo.IPropertyMessage>> PropertyMessages { get; } = new("PropertyMessages", () => new global::System.Collections.Generic.List<global::Neatoo.IPropertyMessage>());
 
-			/// <summary>Interceptor for IsChild.</summary>
-			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsChild { get; } = new("IsChild");
-
 			/// <summary>Interceptor for IsModified.</summary>
 			public global::KnockOff.Interceptors.PropertyGetInterceptor<bool> IsModified { get; } = new("IsModified");
 
@@ -14374,11 +14327,6 @@ partial class UniquePhoneTypeRuleTests
 				get => PropertyMessages.InvokeGet(Strict);
 			}
 
-			bool global::Neatoo.IEntityMetaProperties.IsChild
-			{
-				get => IsChild.InvokeGet(Strict);
-			}
-
 			bool global::Neatoo.IEntityMetaProperties.IsModified
 			{
 				get => IsModified.InvokeGet(Strict);
@@ -14444,7 +14392,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -14477,7 +14424,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -14510,7 +14456,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14543,7 +14488,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14576,7 +14520,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14609,7 +14552,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14642,7 +14584,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(source != null ? () => source.IsValid : null);
 				IsSelfValid.SetSourceFallback(source != null ? () => source.IsSelfValid : null);
 				PropertyMessages.SetSourceFallback(source != null ? () => source.PropertyMessages : null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14675,7 +14616,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(source != null ? () => source.IsChild : null);
 				IsModified.SetSourceFallback(source != null ? () => source.IsModified : null);
 				IsSelfModified.SetSourceFallback(source != null ? () => source.IsSelfModified : null);
 				IsMarkedModified.SetSourceFallback(source != null ? () => source.IsMarkedModified : null);
@@ -14708,7 +14648,6 @@ partial class UniquePhoneTypeRuleTests
 				IsValid.SetSourceFallback(null);
 				IsSelfValid.SetSourceFallback(null);
 				PropertyMessages.SetSourceFallback(null);
-				IsChild.SetSourceFallback(null);
 				IsModified.SetSourceFallback(null);
 				IsSelfModified.SetSourceFallback(null);
 				IsMarkedModified.SetSourceFallback(null);
@@ -14743,7 +14682,6 @@ partial class UniquePhoneTypeRuleTests
 				if (IsValid.CheckVerification() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerification() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerification() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerification() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerification() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerification() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerification() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);
@@ -14783,7 +14721,6 @@ partial class UniquePhoneTypeRuleTests
 				if (IsValid.CheckVerificationAll() is { } isvalidFailure) failures.Add(isvalidFailure);
 				if (IsSelfValid.CheckVerificationAll() is { } isselfvalidFailure) failures.Add(isselfvalidFailure);
 				if (PropertyMessages.CheckVerificationAll() is { } propertymessagesFailure) failures.Add(propertymessagesFailure);
-				if (IsChild.CheckVerificationAll() is { } ischildFailure) failures.Add(ischildFailure);
 				if (IsModified.CheckVerificationAll() is { } ismodifiedFailure) failures.Add(ismodifiedFailure);
 				if (IsSelfModified.CheckVerificationAll() is { } isselfmodifiedFailure) failures.Add(isselfmodifiedFailure);
 				if (IsMarkedModified.CheckVerificationAll() is { } ismarkedmodifiedFailure) failures.Add(ismarkedmodifiedFailure);

--- a/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityListBaseStateTransitionTests.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityListBaseStateTransitionTests.cs
@@ -313,24 +313,6 @@ public class EntityListBaseStateTransitionTests
     }
 
     [TestMethod]
-    public void Add_Item_IsChildSetToTrue()
-    {
-        // Arrange
-        var aggregateRoot = new EntityPerson { FirstName = "Root" };
-        var list = new EntityPersonList();
-        aggregateRoot.ChildList = list;
-
-        var item = new EntityPerson { FirstName = "Child" };
-        Assert.IsFalse(item.IsChild);
-
-        // Act
-        list.Add(item);
-
-        // Assert
-        Assert.IsTrue(item.IsChild);
-    }
-
-    [TestMethod]
     public void Add_Item_WhenPaused_ParentNotSet()
     {
         // Arrange
@@ -352,27 +334,6 @@ public class EntityListBaseStateTransitionTests
 
         // Parent IS set by ListBase even when paused
         Assert.AreEqual(aggregateRoot, item.Parent);
-    }
-
-    [TestMethod]
-    public void Add_Item_WhenPaused_IsChildNotSet()
-    {
-        // Arrange
-        var aggregateRoot = new EntityPerson { FirstName = "Root" };
-        var list = new EntityPersonList();
-        aggregateRoot.ChildList = list;
-
-        list.FactoryStart(FactoryOperation.Fetch);
-
-        var item = new EntityPerson { FirstName = "Child" };
-
-        // Act
-        list.Add(item);
-
-        list.FactoryComplete(FactoryOperation.Fetch);
-
-        // Assert - IsChild is NOT set when paused (MarkAsChild is in EntityListBase, skipped when paused)
-        Assert.IsFalse(item.IsChild);
     }
 
     #endregion

--- a/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityListBaseTests.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityListBaseTests.cs
@@ -86,17 +86,6 @@ public class EntityListBaseTests
     }
 
     [TestMethod]
-    public void EntityListBaseTest_ModifyChild_IsSavable()
-    {
-
-        child.FirstName = Guid.NewGuid().ToString();
-
-        // Lists do not expose IsSavable (not on IEntityListBase interface)
-        // Child entities are not savable (IsSavable false because IsChild=true)
-        Assert.IsFalse(child.IsSavable);
-    }
-
-    [TestMethod]
     public void EntityListBaseTest_Remove()
     {
         list.Remove(list.First());

--- a/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityParentChildFetchTests.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityParentChildFetchTests.cs
@@ -30,7 +30,6 @@ public class EntityParentChildFetchTests
 
         child.MarkOld();
         child.MarkUnmodified();
-        child.MarkAsChild();
         parent.MarkOld();
         parent.MarkUnmodified();
 
@@ -51,9 +50,6 @@ public class EntityParentChildFetchTests
 
         AssertMeta(parent);
         AssertMeta(child);
-
-        Assert.IsFalse(parent.IsChild);
-        Assert.IsTrue(child.IsChild);
 
     }
 
@@ -88,7 +84,6 @@ public class EntityParentChildFetchTests
         await parent.WaitForTasks();
 
         Assert.IsTrue(parent.IsSavable);
-        Assert.IsFalse(child.IsSavable);
 
     }
 

--- a/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityPersonObject.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/EntityBase/EntityPersonObject.cs
@@ -5,7 +5,6 @@ using Neatoo.UnitTest.Integration.Aggregates.Person;
 namespace Neatoo.UnitTest.Integration.Concepts.EntityBase;
 public partial interface IEntityPerson : IPersonEntity
 {
-    void MarkAsChild();
     void MarkNew();
     void MarkOld();
     void MarkUnmodified();
@@ -34,11 +33,6 @@ public partial class EntityPerson : PersonEntityBase<EntityPerson>, IEntityPerso
     public partial List<int> InitiallyDefined { get; set; }
     public partial IEntityPerson Child { get; set; }
     public partial IEntityPersonList ChildList { get; set; }
-
-    void IEntityPerson.MarkAsChild()
-    {
-        this.MarkAsChild();
-    }
 
     void IEntityPerson.MarkDeleted()
     {

--- a/src/Neatoo.UnitTest/Integration/Concepts/Serialization/DisplayNameSerializationTests.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/Serialization/DisplayNameSerializationTests.cs
@@ -28,8 +28,6 @@ public interface IDisplayNameTestEntity : IEntityBase
     /// Child entity for testing nested DisplayName preservation.
     /// </summary>
     IDisplayNameTestEntity? Child { get; set; }
-
-    void MarkEntityAsChild();
 }
 
 /// <summary>
@@ -50,11 +48,6 @@ internal partial class DisplayNameTestEntity : EntityBase<DisplayNameTestEntity>
     public partial string? NameWithoutDisplayName { get; set; }
 
     public partial IDisplayNameTestEntity? Child { get; set; }
-
-    void IDisplayNameTestEntity.MarkEntityAsChild()
-    {
-        MarkAsChild();
-    }
 }
 
 #endregion
@@ -138,7 +131,6 @@ public class DisplayNameSerializationTests : IntegrationTestBase
         var child = GetRequiredService<IDisplayNameTestEntity>();
         child.Id = Guid.NewGuid();
         child.NameWithDisplayName = "Child Value";
-        child.MarkEntityAsChild();
         _target.Child = child;
 
         var originalChildDisplayName = child[nameof(IDisplayNameTestEntity.NameWithDisplayName)]!.DisplayName;

--- a/src/Neatoo.UnitTest/Integration/Concepts/Serialization/EntityObject.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/Serialization/EntityObject.cs
@@ -10,7 +10,6 @@ public interface IEntityObject : IEntityRoot
 
     IEntityObject Child { get; set; }
     IEntityObjectList ChildList { get; set; }
-    void MarkAsChild();
 
     void MarkNew();
 
@@ -47,11 +46,6 @@ public partial class EntityObject : EntityBase<EntityObject>, IEntityObject
     public partial IEntityObjectList ChildList { get; set; }
     [Required]
     public partial int? Required { get; set; }
-
-    void IEntityObject.MarkAsChild()
-    {
-        this.MarkAsChild();
-    }
 
     void IEntityObject.MarkDeleted()
     {

--- a/src/Neatoo.UnitTest/Integration/Concepts/Serialization/FatClientEntityTests.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/Serialization/FatClientEntityTests.cs
@@ -184,32 +184,6 @@ public class FatClientEntityTests : IntegrationTestBase
     }
 
     [TestMethod]
-    public void FatClientEntity_IsChild()
-    {
-
-        _target.MarkAsChild();
-
-        var json = Serialize(_target);
-
-        var newTarget = DeserializeEntity(json);
-
-        Assert.IsTrue(newTarget.IsChild);
-
-    }
-
-    [TestMethod]
-    public void FatClientEntity_IsChild_False()
-    {
-
-        var json = Serialize(_target);
-
-        var newTarget = DeserializeEntity(json);
-
-        Assert.IsFalse(newTarget.IsChild);
-
-    }
-
-    [TestMethod]
     public void FatClientEntity_ModifiedProperties()
     {
 

--- a/src/Neatoo.UnitTest/Integration/Concepts/Serialization/TwoContainerMetaStateTests.cs
+++ b/src/Neatoo.UnitTest/Integration/Concepts/Serialization/TwoContainerMetaStateTests.cs
@@ -81,7 +81,6 @@ public class TwoContainerMetaStateTests : ClientServerTestBase
         // Assert
         Assert.IsTrue(entity.IsValid, "Entity should be valid");
         Assert.IsFalse(entity.IsBusy, "Entity should not be busy");
-        Assert.IsFalse(entity.IsChild, "Entity should not be a child");
         Assert.IsTrue(entity.IsSavable, "Entity should be savable after Create operation");
     }
 

--- a/src/Neatoo.UnitTest/Unit/Core/EntityBaseStateTests.cs
+++ b/src/Neatoo.UnitTest/Unit/Core/EntityBaseStateTests.cs
@@ -8,8 +8,8 @@ namespace Neatoo.UnitTest.Unit.Core;
 
 /// <summary>
 /// Unit tests for EntityBase{T} entity state flags and transitions.
-/// Tests IsNew, IsChild, IsDeleted, IsModified, IsSelfModified, IsSavable, IsMarkedModified,
-/// and the state transition methods (MarkNew, MarkOld, MarkAsChild, MarkDeleted, etc.).
+/// Tests IsNew, IsDeleted, IsModified, IsSelfModified, IsSavable, IsMarkedModified,
+/// and the state transition methods (MarkNew, MarkOld, MarkDeleted, etc.).
 /// Uses real Neatoo classes instead of mocks.
 /// </summary>
 [TestClass]
@@ -34,7 +34,6 @@ public class EntityBaseStateTests
         // Expose protected members for testing
         public new void MarkNew() => base.MarkNew();
         public new void MarkOld() => base.MarkOld();
-        public new void MarkAsChild() => base.MarkAsChild();
         public new void MarkDeleted() => base.MarkDeleted();
         public new void MarkModified() => base.MarkModified();
         public new void MarkUnmodified() => base.MarkUnmodified();
@@ -148,45 +147,6 @@ public class EntityBaseStateTests
 
         // Assert
         Assert.IsFalse(entity.IsNew);
-    }
-
-    #endregion
-
-    #region IsChild Tests
-
-    [TestMethod]
-    public void IsChild_InitialState_ReturnsFalse()
-    {
-        // Arrange
-        var entity = CreateEntity();
-
-        // Assert
-        Assert.IsFalse(entity.IsChild);
-    }
-
-    [TestMethod]
-    public void IsChild_AfterMarkAsChild_ReturnsTrue()
-    {
-        // Arrange
-        var entity = CreateEntity();
-
-        // Act
-        entity.MarkAsChild();
-
-        // Assert
-        Assert.IsTrue(entity.IsChild);
-    }
-
-    [TestMethod]
-    public void IsChild_CannotBeReversed()
-    {
-        // Once marked as child, entity stays as child
-        // Arrange
-        var entity = CreateEntity();
-        entity.MarkAsChild();
-
-        // Assert - No method to unmark as child
-        Assert.IsTrue(entity.IsChild);
     }
 
     #endregion
@@ -512,7 +472,6 @@ public class EntityBaseStateTests
         Assert.IsTrue(entity.IsModified);
         Assert.IsTrue(entity.IsValid);
         Assert.IsFalse(entity.IsBusy);
-        Assert.IsFalse(entity.IsChild);
         Assert.IsTrue(entity.IsSavable);
     }
 
@@ -525,20 +484,6 @@ public class EntityBaseStateTests
 
         // Assert
         Assert.IsFalse(entity.IsModified);
-        Assert.IsFalse(entity.IsSavable);
-    }
-
-    [TestMethod]
-    public void IsSavable_WhenChild_ReturnsFalse()
-    {
-        // Arrange
-        var entity = CreateEntity();
-        entity.Name = "Test";
-        entity.MarkAsChild();
-
-        // Assert
-        Assert.IsTrue(entity.IsModified);
-        Assert.IsTrue(entity.IsChild);
         Assert.IsFalse(entity.IsSavable);
     }
 
@@ -817,19 +762,6 @@ public class EntityBaseStateTests
     #endregion
 
     #region Save Exception Tests
-
-    [TestMethod]
-    public async Task Save_WhenChild_ThrowsSaveOperationException()
-    {
-        // Arrange
-        var entity = CreateEntity();
-        entity.Name = "Test";
-        entity.MarkAsChild();
-
-        // Act & Assert
-        var ex = await Assert.ThrowsExactlyAsync<SaveOperationException>(() => entity.Save());
-        Assert.AreEqual(SaveFailureReason.IsChildObject, ex.Reason);
-    }
 
     [TestMethod]
     public async Task Save_WhenNotModified_ThrowsSaveOperationException()

--- a/src/Neatoo.UnitTest/Unit/Core/EntityListBaseTests.cs
+++ b/src/Neatoo.UnitTest/Unit/Core/EntityListBaseTests.cs
@@ -54,7 +54,6 @@ public class EntityListBaseTests
         // Expose protected members for testing
         public new void MarkNew() => base.MarkNew();
         public new void MarkOld() => base.MarkOld();
-        public new void MarkAsChild() => base.MarkAsChild();
         public new void MarkModified() => base.MarkModified();
         public new void MarkUnmodified() => base.MarkUnmodified();
     }
@@ -168,16 +167,6 @@ public class EntityListBaseTests
         Assert.IsFalse(list.IsDeleted);
     }
 
-    [TestMethod]
-    public void IsChild_AlwaysFalse()
-    {
-        // Lists manage child relationships through their items
-        var list = new TestEntityList();
-
-        // Assert
-        Assert.IsFalse(list.IsChild);
-    }
-
     #endregion
 
     #region IsModified Tests
@@ -251,21 +240,6 @@ public class EntityListBaseTests
     #region Add Item Tests
 
     [TestMethod]
-    public void Add_NewItem_MarksAsChild()
-    {
-        // Arrange
-        var list = new TestEntityList();
-        var item = CreateNewItem();
-        Assert.IsFalse(item.IsChild);
-
-        // Act
-        list.Add(item);
-
-        // Assert
-        Assert.IsTrue(item.IsChild);
-    }
-
-    [TestMethod]
     public void Add_ExistingItem_MarksAsModified()
     {
         // Arrange
@@ -293,21 +267,6 @@ public class EntityListBaseTests
 
         // Assert
         Assert.IsFalse(item.IsDeleted);
-    }
-
-    [TestMethod]
-    public void Add_WhenPaused_DoesNotMarkAsChild()
-    {
-        // Arrange
-        var list = new TestEntityList();
-        list.IsPaused = true;
-        var item = CreateNewItem();
-
-        // Act
-        list.Add(item);
-
-        // Assert
-        Assert.IsFalse(item.IsChild);
     }
 
     [TestMethod]

--- a/src/Neatoo.UnitTest/Unit/Core/LazyLoadTests.cs
+++ b/src/Neatoo.UnitTest/Unit/Core/LazyLoadTests.cs
@@ -417,16 +417,6 @@ public class LazyLoadTests
     // IsSavable tests removed — IsSavable moved to IEntityRoot, no longer on IEntityMetaProperties or EntityLazyLoad<T>
 
     [TestMethod]
-    public void IsChild_BeforeLoad_ReturnsFalse()
-    {
-        // Arrange
-        var lazyLoad = new EntityLazyLoad<TestEntityValue>(() => Task.FromResult<TestEntityValue?>(new TestEntityValue()));
-
-        // Assert
-        Assert.IsFalse(((IEntityMetaProperties)lazyLoad).IsChild);
-    }
-
-    [TestMethod]
     public void IsSelfModified_AlwaysReturnsFalse()
     {
         // Arrange - LazyLoad wrapper itself is never modified
@@ -654,7 +644,6 @@ public class TestEntityValue : IEntityMetaProperties, IValidateMetaProperties
     public bool IsDeletedValue { get; set; }
 
     // IEntityMetaProperties
-    public bool IsChild => false;
     public bool IsModified => IsModifiedValue;
     public bool IsSelfModified => IsModifiedValue;
     public bool IsMarkedModified => false;

--- a/src/Neatoo/EntityBase.cs
+++ b/src/Neatoo/EntityBase.cs
@@ -92,7 +92,6 @@ public interface IEntityRoot : IEntityBase
 /// <item><description>New/existing state tracking via <see cref="IsNew"/></description></item>
 /// <item><description>Soft delete support via <see cref="Delete"/> and <see cref="IsDeleted"/></description></item>
 /// <item><description>Savability determination via <see cref="IsSavable"/></description></item>
-/// <item><description>Child entity support for aggregate patterns via <see cref="IsChild"/></description></item>
 /// </list>
 /// <para>
 /// Entity objects can be persisted through the factory pattern. The <see cref="Save()"/> method
@@ -171,7 +170,7 @@ public abstract class EntityBase<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// <remarks>
     /// Child entities cannot be saved independently; they must be saved through their parent aggregate root.
     /// </remarks>
-    public virtual bool IsSavable => this.IsModified && this.IsValid && !this.IsBusy && !this.IsChild;
+    public virtual bool IsSavable => this.IsModified && this.IsValid && !this.IsBusy;
 
     /// <summary>
     /// Gets or sets a value indicating whether this is a new entity that has not been persisted.
@@ -190,15 +189,6 @@ public abstract class EntityBase<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// </summary>
     /// <value>An enumerable collection of modified property names.</value>
     public virtual IEnumerable<string> ModifiedProperties => this.PropertyManager.ModifiedProperties;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether this entity is a child within an aggregate.
-    /// </summary>
-    /// <value><c>true</c> if this is a child entity; otherwise, <c>false</c>.</value>
-    /// <remarks>
-    /// Child entities are saved as part of their parent aggregate and cannot call <see cref="Save()"/> directly.
-    /// </remarks>
-    public virtual bool IsChild { get; protected set; }
 
     /// <summary>
     /// Gets or sets the list that contains this entity.
@@ -273,18 +263,6 @@ public abstract class EntityBase<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// Gets a value indicating whether this entity has been explicitly marked as modified for interface implementation.
     /// </summary>
     bool IEntityMetaProperties.IsMarkedModified => this.IsMarkedModified;
-
-    /// <summary>
-    /// Marks this entity as a child entity within an aggregate.
-    /// </summary>
-    /// <remarks>
-    /// Child entities cannot be saved independently; they are persisted through their parent aggregate root.
-    /// This method is typically called by list containers when an entity is added.
-    /// </remarks>
-    protected virtual void MarkAsChild()
-    {
-        this.IsChild = true;
-    }
 
     /// <summary>
     /// Marks this entity as unmodified, clearing all modification tracking.
@@ -431,18 +409,11 @@ public abstract class EntityBase<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// <item><description>If <see cref="IsDeleted"/> is <c>true</c>, calls the Delete method</description></item>
     /// <item><description>Otherwise, calls the Update method</description></item>
     /// </list>
-    /// <para>
-    /// Child entities cannot be saved directly; they must be saved through their parent aggregate root.
-    /// </para>
     /// </remarks>
     public virtual async Task<IEntityBase> Save()
     {
         if (!this.IsSavable)
         {
-            if (this.IsChild)
-            {
-                throw new SaveOperationException(SaveFailureReason.IsChildObject);
-            }
             if (!this.IsValid)
             {
                 throw new SaveOperationException(SaveFailureReason.IsInvalid);
@@ -593,14 +564,6 @@ public abstract class EntityBase<[DynamicallyAccessedMembers(DynamicallyAccessed
     void IEntityBaseInternal.MarkModified()
     {
         this.MarkModified();
-    }
-
-    /// <summary>
-    /// Explicit interface implementation for marking the entity as a child.
-    /// </summary>
-    void IEntityBaseInternal.MarkAsChild()
-    {
-        this.MarkAsChild();
     }
 
     /// <summary>

--- a/src/Neatoo/EntityLazyLoad.cs
+++ b/src/Neatoo/EntityLazyLoad.cs
@@ -105,9 +105,6 @@ public class EntityLazyLoad<T> : Neatoo.RemoteFactory.LazyLoad<T>, IValidateMeta
     #region IEntityMetaProperties
 
     /// <inheritdoc />
-    public bool IsChild => (Value as IEntityMetaProperties)?.IsChild ?? false;
-
-    /// <inheritdoc />
     public bool IsModified => (Value as IEntityMetaProperties)?.IsModified ?? false;
 
     /// <inheritdoc />

--- a/src/Neatoo/EntityListBase.cs
+++ b/src/Neatoo/EntityListBase.cs
@@ -90,12 +90,6 @@ public abstract class EntityListBase<I> : ValidateListBase<I>, INeatooObject, IE
     public bool IsDeleted => false;
 
     /// <summary>
-    /// Gets a value indicating whether the list is a child of another entity.
-    /// Always returns <c>false</c> as lists manage child relationships through their items.
-    /// </summary>
-    public bool IsChild => false;
-
-    /// <summary>
     /// Gets the aggregate root of the object graph this list belongs to.
     /// </summary>
     /// <value>
@@ -191,7 +185,7 @@ public abstract class EntityListBase<I> : ValidateListBase<I>, INeatooObject, IE
     /// <summary>
     /// Inserts an item into the collection at the specified index.
     /// When not paused, handles entity state management including undeleting previously deleted items,
-    /// marking existing items as modified, setting child status, and managing ContainingList.
+    /// marking existing items as modified, and managing ContainingList.
     /// </summary>
     /// <param name="index">The zero-based index at which to insert the item.</param>
     /// <param name="item">The entity item to insert into the collection.</param>
@@ -244,12 +238,10 @@ public abstract class EntityListBase<I> : ValidateListBase<I>, INeatooObject, IE
                 itemInternal.MarkModified();
             }
 
-            itemInternal.MarkAsChild();
-
             // Set ContainingList to this list
             itemInternal.SetContainingList(this);
 
-            // Update cached modified state - item will be modified after MarkAsChild/MarkModified
+            // Update cached modified state - item will be modified after MarkModified
             if (item.IsModified)
             {
                 _cachedChildrenModified = true;

--- a/src/Neatoo/Exceptions.cs
+++ b/src/Neatoo/Exceptions.cs
@@ -61,8 +61,6 @@ public abstract class ConfigurationException : NeatooException
 /// </summary>
 public enum SaveFailureReason
 {
-	/// <summary>Child objects cannot be saved directly; save the parent instead.</summary>
-	IsChildObject,
 	/// <summary>The object has validation errors and cannot be saved.</summary>
 	IsInvalid,
 	/// <summary>The object has not been modified, so there is nothing to save.</summary>
@@ -108,7 +106,6 @@ public class SaveOperationException : EntityException
 
 	private static string GetMessage(SaveFailureReason reason) => reason switch
 	{
-		SaveFailureReason.IsChildObject => "Child objects cannot be saved directly. Save the parent object instead.",
 		SaveFailureReason.IsInvalid => "Object is not valid and cannot be saved. Check validation errors before saving.",
 		SaveFailureReason.NotModified => "Object has not been modified. There are no changes to save.",
 		SaveFailureReason.IsBusy => "Object is busy with an async operation and cannot be saved. Call 'await entity.WaitForTasks()' before saving.",

--- a/src/Neatoo/IMetaProperties.cs
+++ b/src/Neatoo/IMetaProperties.cs
@@ -91,15 +91,6 @@ public interface IValidateMetaProperties
 public interface IEntityMetaProperties : IFactorySaveMeta
 {
     /// <summary>
-    /// Gets a value indicating whether this object is a child within an aggregate.
-    /// </summary>
-    /// <value><c>true</c> if the object is a child entity; otherwise, <c>false</c>.</value>
-    /// <remarks>
-    /// Child entities are saved as part of their parent aggregate and cannot be saved independently.
-    /// </remarks>
-    bool IsChild { get; }
-
-    /// <summary>
     /// Gets a value indicating whether the object or any of its children have been modified.
     /// </summary>
     /// <value><c>true</c> if any modifications exist; otherwise, <c>false</c>.</value>

--- a/src/Neatoo/InternalInterfaces.cs
+++ b/src/Neatoo/InternalInterfaces.cs
@@ -71,12 +71,6 @@ internal interface IEntityBaseInternal : IValidateBaseInternal
     void MarkModified();
 
     /// <summary>
-    /// Marks the entity as a child within an aggregate.
-    /// Called by EntityListBase when items are added.
-    /// </summary>
-    void MarkAsChild();
-
-    /// <summary>
     /// Marks the entity for deletion without triggering list removal.
     /// Called by EntityListBase.RemoveItem to avoid recursion with Delete().
     /// </summary>

--- a/src/Neatoo/RemoteFactory/Internal/NeatooBaseJsonTypeConverter.cs
+++ b/src/Neatoo/RemoteFactory/Internal/NeatooBaseJsonTypeConverter.cs
@@ -414,7 +414,7 @@ public class NeatooBaseJsonTypeConverter<T> : JsonConverter<T>
         if (value is IEntityMetaProperties editMetaProperties)
         {
             // IEntityMetaProperties intentionally does not extend IValidateMetaProperties
-            // so this reflection call only picks up persistence state (IsModified, IsChild, etc.)
+            // so this reflection call only picks up persistence state (IsModified, IsNew, IsDeleted, etc.)
             // and not validation state (IsValid, IsBusy, PropertyMessages, etc.)
             var editProperties = typeof(IEntityMetaProperties).GetProperties().ToList();
             editProperties.AddRange(typeof(IFactorySaveMeta).GetProperties());

--- a/src/samples/ApiReferenceSamples.cs
+++ b/src/samples/ApiReferenceSamples.cs
@@ -882,7 +882,6 @@ public class ApiReferenceSamplesTests : SamplesTestBase
         var newEmployee = factory.Create();
         Assert.True(newEmployee.IsNew);   // New entity - will Insert on save
         Assert.False(newEmployee.IsDeleted);
-        Assert.False(newEmployee.IsChild);
 
         // Fetch existing entity
         var existingEmployee = factory.Fetch(1, "Alice", "Engineering");
@@ -1162,8 +1161,7 @@ public class ApiReferenceSamplesTests : SamplesTestBase
         newItem.ProductCode = "NEW-001";
         order.Items.Add(newItem);
 
-        // Item is marked as child and is new
-        Assert.True(newItem.IsChild);
+        // Item is new and parented to the aggregate root
         Assert.True(newItem.IsNew);
         Assert.Same(order, newItem.Parent);
 
@@ -1219,7 +1217,6 @@ public class ApiReferenceSamplesTests : SamplesTestBase
         // IEntityBase adds persistence properties
         Assert.True(employee.IsNew);  // After Create, IsNew is true
         Assert.False(employee.IsDeleted);
-        Assert.False(employee.IsChild);
         Assert.True(employee.IsModified);  // New entity is considered modified
 
         // Delete and UnDelete methods
@@ -1304,7 +1301,6 @@ public class ApiReferenceSamplesTests : SamplesTestBase
         IEntityMetaProperties entityMeta = employeeFactory.Create();
         Assert.True(entityMeta.IsNew);  // After Create
         Assert.False(entityMeta.IsDeleted);
-        Assert.False(entityMeta.IsChild);
         Assert.True(entityMeta.IsModified);  // New entity
         Assert.False(entityMeta.IsSelfModified);
         Assert.False(entityMeta.IsMarkedModified);

--- a/src/samples/ChangeTrackingSamples.cs
+++ b/src/samples/ChangeTrackingSamples.cs
@@ -365,11 +365,10 @@ public class ChangeTrackingSamplesTests : SamplesTestBase
         // Modify the entity
         employee.Name = "Bob";
 
-        // Modified, valid, not busy, not child = savable
+        // Modified, valid, not busy = savable
         Assert.True(employee.IsModified);
         Assert.True(employee.IsValid);
         Assert.False(employee.IsBusy);
-        Assert.False(employee.IsChild);
         Assert.True(employee.IsSavable);
     }
     #endregion

--- a/src/samples/EntitiesSamples.cs
+++ b/src/samples/EntitiesSamples.cs
@@ -648,7 +648,6 @@ public class EntitiesSamplesTests : SamplesTestBase
         Assert.True(order.IsModified);    // Something changed
         Assert.True(order.IsValid);       // Passes validation
         Assert.False(order.IsBusy);       // No async operations
-        Assert.False(order.IsChild);      // Not a child entity
         Assert.True(order.IsSavable);     // Can save!
     }
     #endregion
@@ -668,11 +667,10 @@ public class EntitiesSamplesTests : SamplesTestBase
         item.Price = 29.99m;
         item.Quantity = 1;
 
-        // Add to collection marks entity as child
+        // Add to collection (the item becomes part of the aggregate)
         order.Items.Add(item);
 
-        // Child entity state
-        Assert.True(item.IsChild);
+        // Child entity is reachable through its aggregate root
         Assert.Same(order, item.Root);
 
         // Child interfaces (IEntityBase) don't expose IsSavable or Save().
@@ -740,35 +738,13 @@ public class EntitiesSamplesTests : SamplesTestBase
     }
 
     [Fact]
-    public void AggregateRoot_HasIsChildFalse()
+    public void AggregateRoot_HasNoRootAbove()
     {
         var factory = GetRequiredService<IEntitiesOrderFactory>();
         var order = factory.Create();
 
-        // Aggregate roots are not children
-        Assert.False(order.IsChild);
-
-        // Aggregate roots can call Save() directly
-        Assert.Null(order.Root); // Root has no root above it
-    }
-
-    [Fact]
-    public void ChildEntity_MarkedWhenAddedToList()
-    {
-        var orderFactory = GetRequiredService<IEntitiesOrderFactory>();
-        var itemFactory = GetRequiredService<IEntitiesOrderItemFactory>();
-
-        var order = orderFactory.Create();
-        var item = itemFactory.Create();
-
-        // Before adding to collection
-        Assert.False(item.IsChild);
-
-        // Add to collection
-        order.Items.Add(item);
-
-        // After adding - marked as child
-        Assert.True(item.IsChild);
+        // Aggregate roots can call Save() directly and have no root above them
+        Assert.Null(order.Root);
     }
 
     [Fact]

--- a/src/samples/FactorySamples.cs
+++ b/src/samples/FactorySamples.cs
@@ -272,7 +272,7 @@ public partial class SkillFactoryValidatedOrder : EntityBase<SkillFactoryValidat
     [Insert]
     public async Task InsertAsync([Service] ISkillOrderRepository repository)
     {
-        // IsSavable verifies: IsValid && !IsBusy && IsModified && !IsChild
+        // IsSavable verifies: IsValid && !IsBusy && IsModified
         if (!IsSavable)
         {
             // Validation failed - don't persist

--- a/src/samples/ParentChildSamples.cs
+++ b/src/samples/ParentChildSamples.cs
@@ -217,12 +217,6 @@ public class ParentChildSamplesTests : SamplesTestBase
         // Child entity: Parent set, Root points to aggregate root
         Assert.Same(order, lineItem.Parent);
         Assert.Same(order, lineItem.Root);
-
-        // Child is marked as child entity
-        Assert.True(lineItem.IsChild);
-
-        // Aggregate root is not a child
-        Assert.False(order.IsChild);
     }
     #endregion
 
@@ -309,24 +303,20 @@ public class ParentChildSamplesTests : SamplesTestBase
         item.UnitPrice = 99.99m;
         item.Quantity = 1;
 
-        // Before adding: not a child
-        Assert.False(item.IsChild);
+        // Before adding: standalone entity with no aggregate root
         Assert.Null(item.Root);
 
         // Add to collection
         order.LineItems.Add(item);
 
         // After adding:
-        // 1. IsChild is set to true
-        Assert.True(item.IsChild);
-
-        // 2. Root points to aggregate root
+        // 1. Root points to aggregate root
         Assert.Same(order, item.Root);
 
-        // 3. Parent is set
+        // 2. Parent is set
         Assert.Same(order, item.Parent);
 
-        // 4. Child interfaces (IEntityBase) don't expose IsSavable or Save().
+        // 3. Child interfaces (IEntityBase) don't expose IsSavable or Save().
         //    Only IEntityRoot exposes those members.
         //    This is enforced at the type level — no runtime check needed.
     }

--- a/src/samples/RemoteFactoryIntegrationSamples.cs
+++ b/src/samples/RemoteFactoryIntegrationSamples.cs
@@ -133,8 +133,8 @@ public partial class SkillRfIntegrationChild : EntityBase<SkillRfIntegrationChil
     [Create]
     public void Create()
     {
-        // IsChild = true (set when added to parent collection)
-        // IsSavable/Save() not accessible on IEntityBase (child interface)
+        // IsSavable/Save() not accessible on IEntityBase (child interface) —
+        // children persist through the aggregate root, never on their own
     }
 
     [Fetch]
@@ -182,14 +182,13 @@ public static class SkillRemoteFactoryStateSamples
     /// </summary>
     public static async Task<bool> CheckSavableBeforeSave(SkillRfIntegrationRoot entity)
     {
-        // IsSavable = IsModified && IsValid && !IsBusy && !IsChild
+        // IsSavable = IsModified && IsValid && !IsBusy
         if (!entity.IsSavable)
         {
             // Don't persist - one or more conditions failed:
             // - !IsModified: No changes to save
             // - !IsValid: Validation failed
             // - IsBusy: Async rules still running
-            // - IsChild: Must save through parent aggregate
             return false;
         }
 
@@ -216,8 +215,8 @@ public static class SkillRemoteFactoryStateSamples
         // - child.IsBusy = true → parent.IsBusy = true
 
         // Child cannot save independently:
-        // - child.IsChild = true (after adding to collection)
         // - IsSavable/Save() not accessible on child interface (IEntityBase)
+        //   — children persist through the aggregate root
     }
     #endregion
 

--- a/src/samples/RemoteFactorySamples.cs
+++ b/src/samples/RemoteFactorySamples.cs
@@ -272,7 +272,7 @@ public partial class RfCustomerValidated : EntityBase<RfCustomerValidated>
     public async Task InsertAsync([Service] IRfCustomerRepository repository)
     {
         // Check IsSavable before persisting
-        // IsSavable verifies: IsValid && !IsBusy && IsModified && !IsChild
+        // IsSavable verifies: IsValid && !IsBusy && IsModified
         if (!IsSavable)
         {
             // Validation failed - do not persist

--- a/src/samples/SkillValidationSamples.cs
+++ b/src/samples/SkillValidationSamples.cs
@@ -348,7 +348,7 @@ public partial class SkillValidInvoice : ValidateBase<SkillValidInvoice>
 
 // EntityBase checks validation before save:
 //
-// entity.IsSavable = entity.IsValid && entity.IsModified && !entity.IsBusy && !entity.IsChild
+// entity.IsSavable = entity.IsValid && entity.IsModified && !entity.IsBusy
 //
 // Save() will fail if !IsSavable
 

--- a/src/samples/TestingPatternsTests.cs
+++ b/src/samples/TestingPatternsTests.cs
@@ -316,7 +316,6 @@ public class TestingPatternsTests : SamplesTestBase
 
         // Real collection behavior
         Assert.Equal(2, order.Items.Count);
-        Assert.True(item1.IsChild);
         Assert.Same(order, item1.Parent);
 
         // Remove item
@@ -375,14 +374,12 @@ public class TestingPatternsTests : SamplesTestBase
 
         // Before adding - no parent
         Assert.Null(member.Parent);
-        Assert.False(member.IsChild);
 
         // Add to collection
         dept.Members.Add(member);
 
         // After adding - parent established
         Assert.Same(dept, member.Parent);
-        Assert.True(member.IsChild);
 
         // Root walks to aggregate root
         Assert.Same(dept, member.Root);


### PR DESCRIPTION
## Context

`IsChild` was a save-barrier meant to block saving non-root entities, but it never did so reliably. `MarkAsChild()` was only called when an entity was added to a list **at runtime** (and only while the list was not paused) — children loaded from persistence during a (paused) `Fetch` never got `IsChild = true`. So the `!IsChild` term in `IsSavable` silently failed to protect the most common case.

The real, reliable guarantee that children can't be saved directly is the **interface-first design**: child entity interfaces extend `IEntityBase`, which exposes neither `Save()` nor `IsSavable`, and concrete entity classes are `internal`. `IsChild` was redundant belt-and-suspenders that only worked half the time.

## Changes

- Remove `IsChild` from `EntityBase`, `IEntityMetaProperties`, `EntityListBase`, `EntityLazyLoad`, and the internal `IEntityBaseInternal` (`MarkAsChild`).
- `IsSavable` is now `IsModified && IsValid && !IsBusy`.
- Remove `SaveFailureReason.IsChildObject` and the `Save()` child guard.
- `IsChild` is no longer serialized.
- Update tests, samples, the `Design.Domain` reference, user docs, the skill, and the KnockOff-generated stubs; reframe the rationale around interface-first design.
- Bump version to **0.31.0**; add release note (`docs/release-notes/v0.31.0.md`).

## ⚠️ Breaking change

`IsChild` is removed from the public `IEntityMetaProperties` (and `EntityListBase`/`EntityLazyLoad`), and `SaveFailureReason.IsChildObject` is gone. There is no replacement property — distinguish root vs child via the interface split (`IEntityRoot` vs `IEntityBase`) or `Root`/`Parent`. See the migration guide in the release note.

**Rationale note:** after removal, a child *concrete* that is modified+valid now reports `IsSavable == true` (the concrete still has `IsSavable`; only the child interface hides it). This makes keeping `Save()`/`IsSavable` off the child interface *more* important, not less — the docs are reframed accordingly.

## Verification

- Release build: **0 errors**.
- Tests: **2234 passed, 0 failed** (Neatoo.UnitTest 1782, Samples 253, Design.Tests 102, Person.DomainModel.Tests 55, BaseGenerator.Tests 42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)